### PR TITLE
Update BuildPSI.yml

### DIFF
--- a/.github/workflows/BuildPSI.yml
+++ b/.github/workflows/BuildPSI.yml
@@ -36,14 +36,17 @@ jobs:
           cache: 'yarn'
 
       - name: Install dependencies
+        working-directory: ./PSI
         run: yarn install --immutable
 
       - name: Build PSI Image
+        working-directory: ./PSI
         run: yarn run build
 
       - name: Upload binaries to release
         uses: svenstaro/upload-release-action@v2
         with:
+          working-directory: ./PSI
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: "dist/${{ matrix.file }}"
           asset_name: ${{ matrix.asset_name }}


### PR DESCRIPTION
I have restructured the repo a little, (seperated the VS Solution and the PSI files).

In doing so, have updated the workflow.
I have moved all yarn files to PSI also (as the workflow is set to run in this DIR - at least where the working directory is important?)


Not sure if .gitignore needs updated with new locations?