### PR TITLE
Add possibility to listen to logging events

### DIFF
--- a/Visual Studio Projects/ZWaveJS.NET/ZWaveJS.NET/Enums.cs
+++ b/Visual Studio Projects/ZWaveJS.NET/ZWaveJS.NET/Enums.cs
@@ -70,6 +70,8 @@ namespace ZWaveJS.NET
             public const string MCGetDefinedValueIDs = "multicast_group.get_defined_value_ids";
             public const string MCSupportsCCAPI = "multicast_group.supports_cc_api";
             public const string MCInvokeCCAPI = "multicast_group.invoke_cc_api";
+            public const string StartListeningLogs = "driver.start_listening_logs";
+            public const string StopListeningLogs = "driver.stop_listening_logs";
         }
 
         public enum SecurityClass

--- a/Visual Studio Projects/ZWaveJS.NET/ZWaveJS.NET/Structures.cs
+++ b/Visual Studio Projects/ZWaveJS.NET/ZWaveJS.NET/Structures.cs
@@ -272,4 +272,18 @@ namespace ZWaveJS.NET
         public GrantSecurityClasses grantSecurityClasses { get; set; }
         public Abort abort { get; set; }
     }
+
+    public class LoggingEventArgs
+    {
+        public string formattedMessage { get; set; }
+        public string direction { get; set; }
+        public string primaryTags { get; set; }
+        public string secondaryTags { get; set; }
+        public int? secondaryTagPadding { get; set; }
+        public bool? multiline { get; set; }
+        public string timestamp { get; set; }
+        public string label { get; set; }
+        public string message { get; set; }
+        public string level { get; set; }
+    }
 }


### PR DESCRIPTION
I created methods to start and stop listening for logging events as per https://github.com/zwave-js/zwave-js-server#start-listening-to-logging-events
I did not implement the optional filter parameter as I'm not sure of how it works, and I couldn't find any documentation about it.