### PR TITLE
Make ZWaveNode.endpoints property public and remove GetAllEndpoints method

### DIFF
--- a/Visual Studio Projects/ZWaveJS.NET/ZWaveJS.NET/ZWaveNode.cs
+++ b/Visual Studio Projects/ZWaveJS.NET/ZWaveJS.NET/ZWaveNode.cs
@@ -543,11 +543,6 @@ namespace ZWaveJS.NET
             return EP;
         }
 
-        public Endpoint[] GetAllEndpoints()
-        {
-            return endpoints;
-        }
-
         public Task<CMDResult> GetEndpointCount()
         {
             Guid ID = Guid.NewGuid();
@@ -660,7 +655,7 @@ namespace ZWaveJS.NET
         }
 
         [Newtonsoft.Json.JsonProperty]
-        internal Endpoint[] endpoints { get; set; }
+        public Endpoint[] endpoints { get; internal set; }
         [Newtonsoft.Json.JsonProperty]
         public bool isControllerNode { get; internal set; }
         [Newtonsoft.Json.JsonProperty]


### PR DESCRIPTION
Because `ZWaveNode.endpoints` was internal, `NodesCollection.ReplaceInformation()` wasn't copying this property. So if you added a node to the network, then when called in the `NodeReady `event, the node passed as a parameter always had its `endpoints `property set to null.
To fix that I made it public (with an internal setter) and remove the `GetAllEndpoints  `method which is no longer needed.

Another problem with `NodesCollection.ReplaceInformation()` that I did not fix, is that it calls the setter for `ZWaveNode.name`, `ZWaveNode.location`, `ZWaveNode.keepAwake`, which in turn sends some message backs to the server which are completely unnecessary.
The same thing also happens every time a node is deserialized as those setters are called too.
So I think it would make sense to have some SetName, SetLocation and SetKeepAwake methods and have an internal setter that only updates the local value, like with all other properties.
What do you think?