### PR TITLE
Possibility to create smart start provision entries from DSK.

### DIFF
--- a/Visual Studio Projects/ZWaveJS.NET/ZWaveJS.NET/Controller.cs
+++ b/Visual Studio Projects/ZWaveJS.NET/ZWaveJS.NET/Controller.cs
@@ -380,7 +380,7 @@ namespace ZWaveJS.NET
             return Result.Task;
         }
 
-        // FIXME
+        // CHECKED
         public Task<CMDResult> GetProvisioningEntries()
         {
             Guid ID = Guid.NewGuid();
@@ -398,12 +398,9 @@ namespace ZWaveJS.NET
 
              });
 
-
             Dictionary<string, object> Request = new Dictionary<string, object>();
             Request.Add("messageId", ID);
             Request.Add("command", Enums.Commands.GetProvisioningEntries);
-
-
 
             string RequestPL = Newtonsoft.Json.JsonConvert.SerializeObject(Request);
             _driver.ClientWebSocket.SendInstant(RequestPL);
@@ -975,7 +972,61 @@ namespace ZWaveJS.NET
                 }
             }
 
-          
+            _driver.Callbacks.Add(ID, (JO) =>
+            {
+                CMDResult Res = new CMDResult(JO);
+                Result.SetResult(Res);
+            });
+
+            Dictionary<string, object> Request = new Dictionary<string, object>();
+
+            Request.Add("messageId", ID);
+            Request.Add("command", Enums.Commands.ProvisionSmartStartNode);
+            Request.Add("entry", ProvisioningInformation);
+
+            string RequestPL = Newtonsoft.Json.JsonConvert.SerializeObject(Request);
+            _driver.ClientWebSocket.SendInstant(RequestPL);
+
+            return Result.Task;
+        }
+
+        // CHECKED
+        public Task<CMDResult> ProvisionSmartStartNode(SmartStartProvisioningEntry ProvisioningInformation)
+        {
+            Guid ID = Guid.NewGuid();
+            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
+
+            if (_driver.Options != null && _driver.Options.MissingKeys(true, true))
+            {
+                CMDResult Res = new CMDResult(Enums.ErrorCodes.MissingKeys, "Missing Security Keys in Options", false);
+                Result.SetResult(Res);
+                return Result.Task;
+            }
+
+            if (_driver.Options != null && !_driver.Options.CheckKeyLength())
+            {
+                CMDResult Res = new CMDResult(Enums.ErrorCodes.InvalidkeyLength, "Invalid Key length. All Security Keys must be a 32 character hexadecimal string (representing 16 bytes)", false);
+                Result.SetResult(Res);
+                return Result.Task;
+            }
+
+            if (ProvisioningInformation.protocol == Protocols.ZWaveLongRange)
+            {
+                if (_driver.Options != null && _driver.Options.MissingLRKeys())
+                {
+                    CMDResult Res = new CMDResult(Enums.ErrorCodes.MissingKeys, "Missing LR Security Keys in Options", false);
+                    Result.SetResult(Res);
+                    return Result.Task;
+                }
+
+
+                if (_driver.Options != null && !_driver.Options.CheckKeyLengthLR())
+                {
+                    CMDResult Res = new CMDResult(Enums.ErrorCodes.InvalidkeyLength, "Invalid Key length. All Security Keys must be a 32 character hexadecimal string (representing 16 bytes)", false);
+                    Result.SetResult(Res);
+                    return Result.Task;
+                }
+            }
 
             _driver.Callbacks.Add(ID, (JO) =>
             {

--- a/Visual Studio Projects/ZWaveJS.NET/ZWaveJS.NET/Enums.cs
+++ b/Visual Studio Projects/ZWaveJS.NET/ZWaveJS.NET/Enums.cs
@@ -2,7 +2,12 @@
 {
     public class Enums
     {
-       public enum QRCodeVersion
+        public enum ProvisioningEntryStatus
+        {
+            Active = 0,
+            Inactive = 1,
+        }
+        public enum QRCodeVersion
         {
             S2 = 0,
             SmartStart = 1,

--- a/Visual Studio Projects/ZWaveJS.NET/ZWaveJS.NET/Structures.cs
+++ b/Visual Studio Projects/ZWaveJS.NET/ZWaveJS.NET/Structures.cs
@@ -34,7 +34,7 @@ namespace ZWaveJS.NET
         [Newtonsoft.Json.JsonProperty]
         public int? maxInclusionRequestInterval { get; internal set; }
         [Newtonsoft.Json.JsonProperty]
-        public  string uuid { get; internal set; }
+        public string uuid { get; internal set; }
         [Newtonsoft.Json.JsonProperty]
         public Protocols[] supportedProtocols { get; internal set; }
     }
@@ -168,14 +168,29 @@ namespace ZWaveJS.NET
     {
         internal SmartStartProvisioningEntry() { }
 
+        public SmartStartProvisioningEntry(string dsk, SecurityClass[] securityClasses, Protocols protocol = Protocols.ZWave)
+        {
+            this.dsk = dsk;
+            this.securityClasses = securityClasses;
+            this.requestedSecurityClasses = securityClasses;
+            this.protocol = protocol;
+            this.supportedProtocols = new Protocols[1] { protocol };
+        }
+
+        [Newtonsoft.Json.JsonProperty]
+        public ProvisioningEntryStatus status { get; internal set; }
         [Newtonsoft.Json.JsonProperty]
         public string dsk { get; internal set; }
         [Newtonsoft.Json.JsonProperty]
-        public int[] securityClasses { get; internal set; }
+        public Protocols? protocol { get; internal set; }
+        [Newtonsoft.Json.JsonProperty]
+        public Protocols[] supportedProtocols { get; internal set; }
+        [Newtonsoft.Json.JsonProperty]
+        public SecurityClass[] securityClasses { get; internal set; }
+        [Newtonsoft.Json.JsonProperty]
+        public SecurityClass[] requestedSecurityClasses { get; internal set; }
         [Newtonsoft.Json.JsonProperty]
         public int version { get; internal set; }
-        [Newtonsoft.Json.JsonProperty]
-        public int[] requestedSecurityClasses { get; internal set; }
         [Newtonsoft.Json.JsonProperty]
         public int genericDeviceClass { get; internal set; }
         [Newtonsoft.Json.JsonProperty]
@@ -190,6 +205,8 @@ namespace ZWaveJS.NET
         public int productId { get; internal set; }
         [Newtonsoft.Json.JsonProperty]
         public decimal applicationVersion { get; internal set; }
+        [Newtonsoft.Json.JsonProperty]
+        public int nodeId { get; internal set; }
     }
 
     public class RebuildRoutesOptions


### PR DESCRIPTION
We need a way to use smart start by entering a DSK without scanning a QR code, so I added a constructor to `SmartStartProvisioningEntry`, and created a new `ProvisionSmartStartNode` method that takes a `SmartStartProvisioningEntry `as parameter.
I also checked that `GetProvisioningEntries `works as expected.

In ZWave JS, `QRProvisioningInformation `and `SmartStartProvisioningEntry `are two separates structures so I kept them separate here. But they are very similar, so maybe `QRProvisioningInformation  `should inherit from `SmartStartProvisioningEntry`.

here is some sample code to add a node using smart start by only using its DSK:

```c#
                    string dsk = "22022-56483-47201-35988-31971-34808-14008-40788";
                    Enums.SecurityClass[] secClasses = new Enums.SecurityClass[4];
                    secClasses[0] = Enums.SecurityClass.S0_Legacy;
                    secClasses[1] = Enums.SecurityClass.S2_Authenticated;
                    secClasses[2] = Enums.SecurityClass.S2_Unauthenticated;
                    secClasses[3] = Enums.SecurityClass.S2_AccessControl;
                    SmartStartProvisioningEntry provisioningEntry = new SmartStartProvisioningEntry(dsk, secClasses, Enums.Protocols.ZWave);
                    CMDResult result = Task.Run(async () => await _driver.Controller.ProvisionSmartStartNode(provisioningEntry)).GetAwaiter().GetResult();
```