### PR TITLE
Add ManuallyIdleNotificationValue method to the ZWaveNode class

### DIFF
--- a/Visual Studio Projects/ZWaveJS.NET/ZWaveJS.NET/Enums.cs
+++ b/Visual Studio Projects/ZWaveJS.NET/ZWaveJS.NET/Enums.cs
@@ -183,6 +183,7 @@
             public const string HardReset = "driver.hard_reset";
             public const string SoftReset = "driver.soft_reset";
             public const string ParseQRCodeString = "utils.parse_qr_code_string";
+            public const string ManuallyIdleNotificationValue = "node.manually_idle_notification_value";
         }
 
         public enum SecurityClass

--- a/Visual Studio Projects/ZWaveJS.NET/ZWaveJS.NET/ZWaveNode.cs
+++ b/Visual Studio Projects/ZWaveJS.NET/ZWaveJS.NET/ZWaveNode.cs
@@ -783,6 +783,62 @@ namespace ZWaveJS.NET
             return Result.Task;
         }
 
+        
+        public Task<CMDResult> ManuallyIdleNotificationValue(ValueID VID)
+        {
+            Guid ID = Guid.NewGuid();
+
+            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
+
+            _driver.Callbacks.Add(ID, (JO) =>
+            {
+                CMDResult Res = new CMDResult(JO);
+                Result.SetResult(Res);
+
+            });
+
+            Dictionary<string, object> Request = new Dictionary<string, object>();
+            Request.Add("messageId", ID);
+            Request.Add("command", Enums.Commands.ManuallyIdleNotificationValue);
+            Request.Add("nodeId", this.id);
+            Request.Add("valueId", VID);
+
+            string RequestPL = JsonConvert.SerializeObject(Request);
+            _driver.ClientWebSocket.SendInstant(RequestPL);
+
+            return Result.Task;
+        }
+
+        public Task<CMDResult> ManuallyIdleNotificationValue(int notificationType, int prevValue, int? endpointIndex = null)
+        {
+            Guid ID = Guid.NewGuid();
+
+            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
+
+            _driver.Callbacks.Add(ID, (JO) =>
+            {
+                CMDResult Res = new CMDResult(JO);
+                Result.SetResult(Res);
+
+            });
+
+            Dictionary<string, object> Request = new Dictionary<string, object>();
+            Request.Add("messageId", ID);
+            Request.Add("command", Enums.Commands.ManuallyIdleNotificationValue);
+            Request.Add("nodeId", this.id);
+            Request.Add("notificationType", notificationType);
+            Request.Add("prevValue", prevValue);
+            if (endpointIndex.HasValue)
+            {
+                Request.Add("endpointIndex", endpointIndex.Value);
+            }
+
+            string RequestPL = JsonConvert.SerializeObject(Request);
+            _driver.ClientWebSocket.SendInstant(RequestPL);
+
+            return Result.Task;
+        }
+
         [Newtonsoft.Json.JsonProperty]
         public Endpoint[] endpoints { get; internal set; }
         [Newtonsoft.Json.JsonProperty]


### PR DESCRIPTION
I added  2 methods for the `node.manually_idle_notification_value` command. The [ZWave JS server doc](https://github.com/zwave-js/zwave-js-server/issues/1263) says the one with notificationType/prevValue/endpointIndex parameters is implemented, but only the one with the ValueId parameter actually works.

I created an issue in the server project: https://github.com/zwave-js/zwave-js-server/issues/1263