### PR TITLE
Refactor requests

### DIFF
--- a/Visual Studio Projects/ZWaveJS.NET/ZWaveJS.NET/ConfigManager.cs
+++ b/Visual Studio Projects/ZWaveJS.NET/ZWaveJS.NET/ConfigManager.cs
@@ -14,82 +14,64 @@ namespace ZWaveJS.NET
         {
             _driver = Driver;
 
-            Guid ID = Guid.Empty;
-            string RequestPL = string.Empty;
-            Dictionary<string, object> Request;
-            
-            Request = new Dictionary<string, object>();
-            ID = Guid.NewGuid();
-            Request.Add("messageId", ID);
-            Request.Add("command", Enums.Commands.LoadManufacturers);
-            RequestPL = Newtonsoft.Json.JsonConvert.SerializeObject(Request);
-            _driver.ClientWebSocket.SendInstant(RequestPL);
-            
-            Request = new Dictionary<string, object>();
-            ID = Guid.NewGuid();
-            Request.Add("messageId", ID);
-            Request.Add("command", Enums.Commands.LoadDeviceIndex);
-            RequestPL = Newtonsoft.Json.JsonConvert.SerializeObject(Request);
-            _driver.ClientWebSocket.SendInstant(RequestPL);
-    
-           
+            // Fire-and-forget the load commands but observe failures to avoid unobserved exceptions.
+            var req1 = new Dictionary<string, object>
+            {
+                { "command", Enums.Commands.LoadManufacturers }
+            };
+            _ = _driver.SendRequestAsync(req1).ContinueWith(t =>
+            {
+                System.Diagnostics.Debug.WriteLine($"LoadManufacturers request failed: {t.Exception?.GetBaseException()}");
+            }, TaskContinuationOptions.OnlyOnFaulted);
+
+            var req2 = new Dictionary<string, object>
+            {
+                { "command", Enums.Commands.LoadDeviceIndex }
+            };
+            _ = _driver.SendRequestAsync(req2).ContinueWith(t =>
+            {
+                System.Diagnostics.Debug.WriteLine($"LoadDeviceIndex request failed: {t.Exception?.GetBaseException()}");
+            }, TaskContinuationOptions.OnlyOnFaulted);
         }
 
         // Checked as of : 3.5.0
         public Task<CMDResult> LookupDevice(int ManufacturerID, int ProductTypeID, int ProductId)
         {
-            
-            Guid ID = Guid.NewGuid();
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
-            _driver.Callbacks.Add(ID, (JO) =>
+            var request = new Dictionary<string, object>
             {
-                CMDResult Res = new CMDResult(JO);
+                { "command", Enums.Commands.LookupDevice },
+                { "manufacturerId", ManufacturerID },
+                { "productType", ProductTypeID },
+                { "productId", ProductId }
+            };
+
+            return _driver.SendRequestAsync(request, (JO, Res) =>
+            {
                 if (Res.Success)
                 {
                     DeviceConfig Config = JO.SelectToken("result.config").ToObject<DeviceConfig>();
                     Res.SetPayload(Config);
                 }
-                Result.SetResult(Res);
             });
-
-            Dictionary<string, object> Request = new Dictionary<string, object>();
-            Request.Add("messageId", ID);
-            Request.Add("command", Enums.Commands.LookupDevice);
-            Request.Add("manufacturerId", ManufacturerID);
-            Request.Add("productType", ProductTypeID);
-            Request.Add("productId", ProductId);
-            
-            string RequestPL = Newtonsoft.Json.JsonConvert.SerializeObject(Request);
-            _driver.ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
         }
 
         // Checked as of : 3.5.0
         public Task<CMDResult> LookupManufacturer(int ManufacturerID)
         {
-            Guid ID = Guid.NewGuid();
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
-            _driver.Callbacks.Add(ID, (JO) =>
+            var request = new Dictionary<string, object>
             {
-                CMDResult Res = new CMDResult(JO);
+                { "command", Enums.Commands.LookupManufacturer },
+                { "manufacturerId", ManufacturerID }
+            };
+
+            return _driver.SendRequestAsync(request, (JO, Res) =>
+            {
                 if (Res.Success)
                 {
                     string Name = JO.SelectToken("result.name").ToObject<string>();
                     Res.SetPayload(Name);
                 }
-                Result.SetResult(Res);
             });
-
-            Dictionary<string, object> Request = new Dictionary<string, object>();
-            Request.Add("messageId", ID);
-            Request.Add("command", Enums.Commands.LookupManufacturer);
-            Request.Add("manufacturerId", ManufacturerID);
-            
-            string RequestPL = Newtonsoft.Json.JsonConvert.SerializeObject(Request);
-            _driver.ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
         }
     }
 }

--- a/Visual Studio Projects/ZWaveJS.NET/ZWaveJS.NET/Controller.cs
+++ b/Visual Studio Projects/ZWaveJS.NET/ZWaveJS.NET/Controller.cs
@@ -144,439 +144,268 @@ namespace ZWaveJS.NET
         // Checked as of : 3.5.0
         public Task<CMDResult> GetAvailableFirmwareUpdates(int NodeID, bool IncludePrereleases, UsageEnvironment Environment, string APIKey = null)
         {
-            Guid ID = Guid.NewGuid();
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
-
             if (Environment == UsageEnvironment.Commercial && string.IsNullOrEmpty(APIKey))
             {
                 CMDResult Res = new CMDResult(Enums.ErrorCodes.CommercialAPIKey, "A valid API license key is required for commercial use", false);
-                Result.SetResult(Res);
-                return Result.Task;
+                return Task.FromResult(Res);
             }
 
-            _driver.Callbacks.Add(ID, (JO) =>
+            var request = new Dictionary<string, object>
             {
-                CMDResult Res = new CMDResult(JO);
-                
+                { "command", Enums.Commands.GetAvailableFirmwareUpdates },
+                { "nodeId", NodeID },
+                { "apiKey", APIKey ?? Driver.FWUSAPIKey },
+                { "includePrereleases", IncludePrereleases }
+            };
 
+            return _driver.SendRequestAsync(request, (JO, Res) =>
+            {
                 if (Res.Success)
                 {
                     FirmwareUpdateInfo[] FUI = JO.SelectToken("result.updates").ToObject<FirmwareUpdateInfo[]>();
                     Res.SetPayload(FUI);
                 }
-                Result.SetResult(Res);
-
             });
-
-            Dictionary<string, object> Request = new Dictionary<string, object>();
-            Request.Add("messageId", ID);
-            Request.Add("command", Enums.Commands.GetAvailableFirmwareUpdates);
-            Request.Add("nodeId", NodeID);
-            Request.Add("apiKey", APIKey ?? Driver.FWUSAPIKey);
-            Request.Add("includePrereleases", IncludePrereleases);
-
-            string RequestPL = Newtonsoft.Json.JsonConvert.SerializeObject(Request);
-            _driver.ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
         }
 
         // Checked as of : 3.5.0
         public Task<CMDResult> FirmwareUpdateOTA(int NodeID, FirmwareUpdateInfo Update)
         {
-            Guid ID = Guid.NewGuid();
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
-
-            _driver.Callbacks.Add(ID, (JO) =>
+            var request = new Dictionary<string, object>
             {
-                CMDResult Res = new CMDResult(JO);
+                { "command", Enums.Commands.FirmwareUpdateOTA },
+                { "nodeId", NodeID },
+                { "updateInfo", Update }
+            };
+
+            return _driver.SendRequestAsync(request, (JO, Res) =>
+            {
                 if (Res.Success)
                 {
                     NodeFirmwareUpdateResultArgs FUR = JO.SelectToken("result.result").ToObject<NodeFirmwareUpdateResultArgs>();
                     Res.SetPayload(FUR);
                 }
-                Result.SetResult(Res);
             });
-
-            Dictionary<string, object> Request = new Dictionary<string, object>();
-            Request.Add("messageId", ID);
-            Request.Add("command", Enums.Commands.FirmwareUpdateOTA);
-            Request.Add("nodeId", NodeID);
-            Request.Add("updateInfo", Update);
-
-            string RequestPL = Newtonsoft.Json.JsonConvert.SerializeObject(Request);
-            _driver.ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
         }
 
         // Checked as of : 3.5.0
         public Task<CMDResult> GetRFRegion()
         {
-            Guid ID = Guid.NewGuid();
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
-
-            _driver.Callbacks.Add(ID, (JO) =>
+            var request = new Dictionary<string, object>
             {
-                CMDResult Res = new CMDResult(JO);
+                { "command", Enums.Commands.GetRFRegion }
+            };
+
+            return _driver.SendRequestAsync(request, (JO, Res) =>
+            {
                 if (Res.Success)
                 {
                     Enums.RFRegion Region = JO.SelectToken("result.region").ToObject<Enums.RFRegion>();
                     Res.SetPayload(Region);
                 }
-                Result.SetResult(Res);
-
             });
-            
-            Dictionary<string, object> Request = new Dictionary<string, object>();
-            Request.Add("messageId", ID);
-            Request.Add("command", Enums.Commands.GetRFRegion);
-            
-            string RequestPL = Newtonsoft.Json.JsonConvert.SerializeObject(Request);
-            _driver.ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
         }
 
         // Checked as of : 3.5.0
         public Task<CMDResult> SetRFRegion(Enums.RFRegion Region)
         {
-            Guid ID = Guid.NewGuid();
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
-
-            _driver.Callbacks.Add(ID, (JO) =>
+            var request = new Dictionary<string, object>
             {
-                CMDResult Res = new CMDResult(JO);
-                Result.SetResult(Res);
-            });
-            
-            Dictionary<string, object> Request = new Dictionary<string, object>();
-            Request.Add("messageId", ID);
-            Request.Add("command", Enums.Commands.SetRFRegion);
-            Request.Add("region", Region);
+                { "command", Enums.Commands.SetRFRegion },
+                { "region", Region }
+            };
 
-            string RequestPL = Newtonsoft.Json.JsonConvert.SerializeObject(Request);
-            _driver.ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
+            return _driver.SendRequestAsync(request);
         }
         
         // Checked as of : 3.5.0
         public Task<CMDResult> SetMaxLongRangePowerlevel(decimal Limit)
         {
-            Guid ID = Guid.NewGuid();
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
-
-            _driver.Callbacks.Add(ID, (JO) =>
+            var request = new Dictionary<string, object>
             {
-                CMDResult Res = new CMDResult(JO);
-                Result.SetResult(Res);
-            });
+                { "limit", Limit },
+                { "command", Enums.Commands.SetLRMaxPower }
+            };
 
-            Dictionary<string, object> Request = new Dictionary<string, object>();
-            Request.Add("messageId", ID);
-            Request.Add("limit", Limit);
-            Request.Add("command", Enums.Commands.SetLRMaxPower);
-
-
-            string RequestPL = Newtonsoft.Json.JsonConvert.SerializeObject(Request);
-            _driver.ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
+            return _driver.SendRequestAsync(request);
         }
 
         // Checked as of : 3.5.0
         public Task<CMDResult> GetMaxLongRangePowerlevel()
         {
-            Guid ID = Guid.NewGuid();
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
-
-            _driver.Callbacks.Add(ID, (JO) =>
+            var request = new Dictionary<string, object>
             {
-                CMDResult Res = new CMDResult(JO);
+                { "command", Enums.Commands.GetLRMaxPower }
+            };
 
+            return _driver.SendRequestAsync(request, (JO, Res) =>
+            {
                 if (Res.Success)
                 {
                     decimal Level = JO.SelectToken("result.limit").ToObject<decimal>();
                     Res.SetPayload(Level);
                 }
-                Result.SetResult(Res);
-
             });
-
-            Dictionary<string, object> Request = new Dictionary<string, object>();
-            Request.Add("messageId", ID);
-            Request.Add("command", Enums.Commands.GetLRMaxPower);
-
-
-            string RequestPL = Newtonsoft.Json.JsonConvert.SerializeObject(Request);
-            _driver.ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
         }
 
         // Checked as of : 3.5.0
         public Task<CMDResult> GetPowerLevel()
         {
-            Guid ID = Guid.NewGuid();
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
-
-            _driver.Callbacks.Add(ID, (JO) =>
+            var request = new Dictionary<string, object>
             {
-                CMDResult Res = new CMDResult(JO);
+                { "command", Enums.Commands.GetPowerlevel }
+            };
 
+            return _driver.SendRequestAsync(request, (JO, Res) =>
+            {
                 if (Res.Success)
                 {
                     PowerLevel Level = JO.SelectToken("result").ToObject<PowerLevel>();
                     Res.SetPayload(Level);
                 }
-                Result.SetResult(Res);
-
             });
-
-            Dictionary<string, object> Request = new Dictionary<string, object>();
-            Request.Add("messageId", ID);
-            Request.Add("command", Enums.Commands.GetPowerlevel);
-
-
-            string RequestPL = Newtonsoft.Json.JsonConvert.SerializeObject(Request);
-            _driver.ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
         }
 
         // Checked as of : 3.5.0
         public Task<CMDResult> SetPowerLevel(decimal PowerLevel, decimal Measured0dBm)
         {
-            Guid ID = Guid.NewGuid();
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
-
-            _driver.Callbacks.Add(ID, (JO) =>
+            var request = new Dictionary<string, object>
             {
-                CMDResult Res = new CMDResult(JO);
-                Result.SetResult(Res);
+                { "command", Enums.Commands.SetPowerlevel },
+                { "powerlevel", PowerLevel },
+                { "measured0dBm", Measured0dBm }
+            };
 
-            });
-
-            Dictionary<string, object> Request = new Dictionary<string, object>();
-            Request.Add("messageId", ID);
-            Request.Add("command", Enums.Commands.SetPowerlevel);
-            Request.Add("powerlevel", PowerLevel);
-            Request.Add("measured0dBm", Measured0dBm);
-
-            string RequestPL = Newtonsoft.Json.JsonConvert.SerializeObject(Request);
-            _driver.ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
+            return _driver.SendRequestAsync(request);
         }
 
       
+
 
         // Checked as of : 3.5.0
         public Task<CMDResult> FirmwareUpdateOTW(FirmwareUpdate Update)
         {
             if (Update.firmwareTarget != null)
             {
-                TaskCompletionSource<CMDResult> Fail = new TaskCompletionSource<CMDResult>();
                 CMDResult Res = new CMDResult(Enums.ErrorCodes.WrongOverride, "Please use the override that DOES NOT include 'firmwareTarget'", false);
-                Fail.SetResult(Res);
-
-                return Fail.Task;
+                return Task.FromResult(Res);
             }
 
-            Guid ID = Guid.NewGuid();
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
-
-            _driver.Callbacks.Add(ID, (JO) =>
+            var request = new Dictionary<string, object>
             {
-                CMDResult Res = new CMDResult(JO);
+                { "command", Enums.Commands.FirmwareUpdateOTW },
+                { "file", Update.data },
+                { "filename", Update.filename }
+            };
 
+            return _driver.SendRequestAsync(request, (JO, Res) =>
+            {
                 if (Res.Success)
                 {
                     ControllerFirmwareUpdateResultArgs UpdateResult = JO.SelectToken("result.result").ToObject<ControllerFirmwareUpdateResultArgs>();
                     Res.SetPayload(UpdateResult);
                 }
-                Result.SetResult(Res);
-
             });
-
-
-            Dictionary<string, object> Request = new Dictionary<string, object>();
-            Request.Add("messageId", ID);
-            Request.Add("command", Enums.Commands.FirmwareUpdateOTW);
-            Request.Add("file", Update.data);
-            Request.Add("filename", Update.filename);
-            
-            string RequestPL = Newtonsoft.Json.JsonConvert.SerializeObject(Request);
-            _driver.ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
         }
 
         // Checked as of : 3.5.0
         public Task<CMDResult> GetProvisioningEntries()
         {
-            Guid ID = Guid.NewGuid();
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
-            _driver.Callbacks.Add(ID, (JO) =>
-             {
-                 CMDResult Res = new CMDResult(JO);
+            var request = new Dictionary<string, object>
+            {
+                { "command", Enums.Commands.GetProvisioningEntries }
+            };
 
-                 if (Res.Success)
-                 {
-                     SmartStartProvisioningEntry[] Entries = JO.SelectToken("result.entries").ToObject<SmartStartProvisioningEntry[]>();
-                     Res.SetPayload(Entries);
-                 }
-                 Result.SetResult(Res);
-
-             });
-
-            Dictionary<string, object> Request = new Dictionary<string, object>();
-            Request.Add("messageId", ID);
-            Request.Add("command", Enums.Commands.GetProvisioningEntries);
-
-            string RequestPL = Newtonsoft.Json.JsonConvert.SerializeObject(Request);
-            _driver.ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
+            return _driver.SendRequestAsync(request, (JO, Res) =>
+            {
+                if (Res.Success)
+                {
+                    SmartStartProvisioningEntry[] Entries = JO.SelectToken("result.entries").ToObject<SmartStartProvisioningEntry[]>();
+                    Res.SetPayload(Entries);
+                }
+            });
         }
 
         // Checked as of : 3.5.0
         public Task<CMDResult> ToggleRF(bool Enabled)
         {
-            Guid ID = Guid.NewGuid();
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
-            _driver.Callbacks.Add(ID, (JO) =>
+            var request = new Dictionary<string, object>
             {
-                CMDResult Res = new CMDResult(JO);
-                Result.SetResult(Res);
+                { "command", Enums.Commands.ToggleRF },
+                { "enabled", Enabled }
+            };
 
-            });
-
-            Dictionary<string, object> Request = new Dictionary<string, object>();
-            Request.Add("messageId", ID);
-            Request.Add("command", Enums.Commands.ToggleRF);
-            Request.Add("enabled", Enabled);
-            
-            string RequestPL = Newtonsoft.Json.JsonConvert.SerializeObject(Request);
-            _driver.ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
+            return _driver.SendRequestAsync(request);
         }
 
         // Checked as of : 3.5.0
         public Task<CMDResult> RemoveAssociations(AssociationAddress Source, int Group, AssociationAddress[] Targets)
         {
-            Guid ID = Guid.NewGuid();
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
-            _driver.Callbacks.Add(ID, (JO) =>
-             {
-                 CMDResult Res = new CMDResult(JO);
-                 Result.SetResult(Res);
+            var request = new Dictionary<string, object>
+            {
+                { "command", Enums.Commands.RemoveAssociations },
+                { "nodeId", Source.nodeId },
+                { "endpoint", Source.endpoint },
+                { "group", Group },
+                { "associations", Targets }
+            };
 
-             });
-
-            Dictionary<string, object> Request = new Dictionary<string, object>();
-            Request.Add("messageId", ID);
-            Request.Add("command", Enums.Commands.RemoveAssociations);
-            Request.Add("nodeId", Source.nodeId);
-            Request.Add("endpoint", Source.endpoint);
-            Request.Add("group", Group);
-            Request.Add("associations", Targets);
-
-
-            string RequestPL = Newtonsoft.Json.JsonConvert.SerializeObject(Request);
-            _driver.ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
+            return _driver.SendRequestAsync(request);
         }
 
         // Checked as of : 3.5.0
         public Task<CMDResult> AddAssociations(AssociationAddress Source, int Group, AssociationAddress[] Targets)
         {
-            Guid ID = Guid.NewGuid();
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
-           _driver.Callbacks.Add(ID, (JO) =>
+            var request = new Dictionary<string, object>
             {
-                CMDResult Res = new CMDResult(JO);
-                Result.SetResult(Res);
+                { "command", Enums.Commands.AddAssociations },
+                { "nodeId", Source.nodeId },
+                { "endpoint", Source.endpoint },
+                { "group", Group },
+                { "associations", Targets }
+            };
 
-            });
-
-            Dictionary<string, object> Request = new Dictionary<string, object>();
-            Request.Add("messageId", ID);
-            Request.Add("command", Enums.Commands.AddAssociations);
-            Request.Add("nodeId", Source.nodeId);
-            Request.Add("endpoint", Source.endpoint);
-            Request.Add("group", Group);
-            Request.Add("associations", Targets);
-
-
-            string RequestPL = Newtonsoft.Json.JsonConvert.SerializeObject(Request);
-           _driver.ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
+            return _driver.SendRequestAsync(request);
         }
 
         // Checked as of : 3.5.0
         public Task<CMDResult> GetAssociations(int Node, int Endpoint)
         {
-            Guid ID = Guid.NewGuid();
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
-            _driver.Callbacks.Add(ID, (JO) =>
-             {
-                 CMDResult Res = new CMDResult(JO);
-                 if (Res.Success)
-                 {
-                     Dictionary<int, AssociationAddress[]> Associations = JO.SelectToken("result.associations").ToObject<Dictionary<int, AssociationAddress[]>>();
-                     Res.SetPayload(Associations);
-                 }
+            var request = new Dictionary<string, object>
+            {
+                { "command", Enums.Commands.GetAssociations },
+                { "nodeId", Node },
+                { "endpoint", Endpoint }
+            };
 
-                 Result.SetResult(Res);
-
-             });
-
-            Dictionary<string, object> Request = new Dictionary<string, object>();
-            Request.Add("messageId", ID);
-            Request.Add("command", Enums.Commands.GetAssociations);
-            Request.Add("nodeId", Node);
-            Request.Add("endpoint", Endpoint);
-
-            string RequestPL = Newtonsoft.Json.JsonConvert.SerializeObject(Request);
-            _driver.ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
+            return _driver.SendRequestAsync(request, (JO, Res) =>
+            {
+                if (Res.Success)
+                {
+                    Dictionary<int, AssociationAddress[]> Associations = JO.SelectToken("result.associations").ToObject<Dictionary<int, AssociationAddress[]>>();
+                    Res.SetPayload(Associations);
+                }
+            });
         }
 
         // Checked as of : 3.5.0
         public Task<CMDResult> GetAssociationGroups(int Node, int Endpoint)
         {
-            Guid ID = Guid.NewGuid();
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
-            _driver.Callbacks.Add(ID, (JO) =>
-             {
-                 CMDResult Res = new CMDResult(JO);
-                 if (Res.Success)
-                 {
-                     Dictionary<int, AssociationGroup> Groups = JO.SelectToken("result.groups").ToObject<Dictionary<int, AssociationGroup>>();
+            var request = new Dictionary<string, object>
+            {
+                { "command", Enums.Commands.GetAssociationGroups },
+                { "nodeId", Node },
+                { "endpoint", Endpoint }
+            };
 
-                     Res.SetPayload(Groups);
-                 }
-
-                 Result.SetResult(Res);
-
-             });
-
-            Dictionary<string, object> Request = new Dictionary<string, object>();
-            Request.Add("messageId", ID);
-            Request.Add("command", Enums.Commands.GetAssociationGroups);
-            Request.Add("nodeId", Node);
-            Request.Add("endpoint", Endpoint);
-
-            string RequestPL = Newtonsoft.Json.JsonConvert.SerializeObject(Request);
-            _driver.ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
+            return _driver.SendRequestAsync(request, (JO, Res) =>
+            {
+                if (Res.Success)
+                {
+                    Dictionary<int, AssociationGroup> Groups = JO.SelectToken("result.groups").ToObject<Dictionary<int, AssociationGroup>>();
+                    Res.SetPayload(Groups);
+                }
+            });
         }
 
         // Checked as of : 3.5.0
@@ -585,28 +414,19 @@ namespace ZWaveJS.NET
             ConvertRestoreNVMProgressSub = ConvertProgress;
             RestoreNVMProgressSub = RestoreProgress;
 
-            Guid ID = Guid.NewGuid();
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
-            _driver.Callbacks.Add(ID, (JO) =>
-             {
-                 CMDResult Res = new CMDResult(JO);
-                 if (Res.Success)
-                 {
-                     _driver.Restart();
-                 }
-                 Result.SetResult(Res);
+            var request = new Dictionary<string, object>
+            {
+                { "command", Enums.Commands.RestoreNVM },
+                { "nvmData", Convert.ToBase64String(NVMData) }
+            };
 
-             });
-
-            Dictionary<string, object> Request = new Dictionary<string, object>();
-            Request.Add("messageId", ID);
-            Request.Add("command", Enums.Commands.RestoreNVM);
-            Request.Add("nvmData", Convert.ToBase64String(NVMData));
-
-            string RequestPL = Newtonsoft.Json.JsonConvert.SerializeObject(Request);
-            _driver.ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
+            return _driver.SendRequestAsync(request, (JO, Res) =>
+            {
+                if (Res.Success)
+                {
+                    _driver.Restart();
+                }
+            });
         }
 
         // Checked as of : 3.5.0
@@ -614,29 +434,19 @@ namespace ZWaveJS.NET
         {
             BackupNVMProgressSub = OnProgress;
 
-            Guid ID = Guid.NewGuid();
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
-            _driver.Callbacks.Add(ID, (JO) =>
-             {
-                 CMDResult Res = new CMDResult(JO);
-                 if (Res.Success)
-                 {
-                     string B64 = JO.SelectToken("result.nvmData").ToObject<string>();
-                     Res.SetPayload(Convert.FromBase64String(B64));
-                 }
+            var request = new Dictionary<string, object>
+            {
+                { "command", Enums.Commands.BackUpNVM }
+            };
 
-                 Result.SetResult(Res);
-
-             });
-
-            Dictionary<string, object> Request = new Dictionary<string, object>();
-            Request.Add("messageId", ID);
-            Request.Add("command", Enums.Commands.BackUpNVM);
-
-            string RequestPL = Newtonsoft.Json.JsonConvert.SerializeObject(Request);
-            _driver.ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
+            return _driver.SendRequestAsync(request, (JO, Res) =>
+            {
+                if (Res.Success)
+                {
+                    string B64 = JO.SelectToken("result.nvmData").ToObject<string>();
+                    Res.SetPayload(Convert.FromBase64String(B64));
+                }
+            });
         }
 
         // Checked as of : 3.5.0
@@ -646,22 +456,17 @@ namespace ZWaveJS.NET
             GrantSecurityClassesSub = null;
             AbortSub = null;
 
-            Guid ID = Guid.NewGuid();
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
-
             switch (Options.strategy)
             {
                 case Enums.InclusionStrategy.Default:
-                    CMDResult Res = new CMDResult(Enums.ErrorCodes.InvalidStrategy, "Invalid Strategy for 'ReplaceFailedNode' Valid Strategies are : [Insecure, Security_S0, Security_S2]", false);
-                    Result.SetResult(Res);
-                    return Result.Task;
+                    CMDResult invalid = new CMDResult(Enums.ErrorCodes.InvalidStrategy, "Invalid Strategy for 'ReplaceFailedNode' Valid Strategies are : [Insecure, Security_S0, Security_S2]", false);
+                    return Task.FromResult(invalid);
 
                 case Enums.InclusionStrategy.Security_S2:
                     ValidateDSKAndEnterPINSub = Options.userCallbacks?.validateDSKAndEnterPIN ?? null;
                     GrantSecurityClassesSub = Options.userCallbacks?.grantSecurityClasses ?? null;
                     AbortSub = Options.userCallbacks?.abort ?? null;
                     break;
-
             }
 
             if (Options.strategy == Enums.InclusionStrategy.Security_S2)
@@ -669,15 +474,13 @@ namespace ZWaveJS.NET
                 if (ValidateDSKAndEnterPINSub == null || GrantSecurityClassesSub == null || AbortSub == null)
                 {
                     CMDResult Res = new CMDResult(Enums.ErrorCodes.MissingS2Callbacks, "S2 Security require userCallbacks to be provided [validateDSKAndEnterPIN, grantSecurityClasses, abort]", false);
-                    Result.SetResult(Res);
-                    return Result.Task;
+                    return Task.FromResult(Res);
                 }
 
                 if (_driver.Options != null && _driver.Options.MissingKeys(true, false))
                 {
                     CMDResult Res = new CMDResult(Enums.ErrorCodes.MissingKeys, "Missing Security Keys in Options", false);
-                    Result.SetResult(Res);
-                    return Result.Task;
+                    return Task.FromResult(Res);
                 }
             }
 
@@ -686,142 +489,88 @@ namespace ZWaveJS.NET
                 if (_driver.Options != null && _driver.Options.MissingKeys(false, true))
                 {
                     CMDResult Res = new CMDResult(Enums.ErrorCodes.MissingKeys, "Missing Security Keys in Options", false);
-                    Result.SetResult(Res);
-                    return Result.Task;
+                    return Task.FromResult(Res);
                 }
             }
 
             if (_driver.Options != null && !_driver.Options.CheckKeyLength())
             {
                 CMDResult Res = new CMDResult(Enums.ErrorCodes.InvalidkeyLength, "Invalid Key length. All Security Keys must be a 32 character hexadecimal string (representing 16 bytes)", false);
-                Result.SetResult(Res);
-                return Result.Task;
+                return Task.FromResult(Res);
             }
 
+            var optionsDict = new Dictionary<string, object>
+            {
+                { "strategy", (int)Options.strategy }
+            };
 
-            _driver.Callbacks.Add(ID, (JO) =>
-             {
-                 CMDResult Res = new CMDResult(JO);
-                 Result.SetResult(Res);
-             });
+            var request = new Dictionary<string, object>
+            {
+                { "command", Enums.Commands.ReplaceFailedNode },
+                { "nodeId", NodeID },
+                { "options", optionsDict }
+            };
 
-            Dictionary<string, object> _Options = new Dictionary<string, object>();
-            _Options.Add("strategy", (int)Options.strategy);
-
-            Dictionary<string, object> Request = new Dictionary<string, object>();
-            Request.Add("messageId", ID);
-            Request.Add("command", Enums.Commands.ReplaceFailedNode);
-            Request.Add("nodeId", NodeID);
-            Request.Add("options", _Options);
-
-            string RequestPL = Newtonsoft.Json.JsonConvert.SerializeObject(Request);
-            _driver.ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
+            return _driver.SendRequestAsync(request);
         }
 
         // Checked as of : 3.5.0
         public Task<CMDResult> RemoveFailedNode(int NodeID)
         {
-            Guid ID = Guid.NewGuid();
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
+            var request = new Dictionary<string, object>
+            {
+                { "command", Enums.Commands.RemoveFailedNode },
+                { "nodeId", NodeID }
+            };
 
-            _driver.Callbacks.Add(ID, (JO) =>
-             {
-                 CMDResult RES = new CMDResult(JO);
-                 Result.SetResult(RES);
-             });
-
-            Dictionary<string, object> Request = new Dictionary<string, object>();
-
-            Request.Add("messageId", ID);
-            Request.Add("command", Enums.Commands.RemoveFailedNode);
-            Request.Add("nodeId", NodeID);
-
-            string RequestPL = Newtonsoft.Json.JsonConvert.SerializeObject(Request);
-            _driver.ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
+            return _driver.SendRequestAsync(request);
         }
 
         // Checked as of : 3.5.0
         public Task<CMDResult> RebuildNodeRoutes(int NodeID)
         {
-            Guid ID = Guid.NewGuid();
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
+            var request = new Dictionary<string, object>
+            {
+                { "command", Enums.Commands.RebuildNodeRoutes },
+                { "nodeId", NodeID }
+            };
 
-            _driver.Callbacks.Add(ID, (JO) =>
-             {
-                 CMDResult Res = new CMDResult(JO);
-                 Result.SetResult(Res);
-             });
-
-            Dictionary<string, object> Request = new Dictionary<string, object>();
-
-            Request.Add("messageId", ID);
-            Request.Add("command", Enums.Commands.RebuildNodeRoutes);
-            Request.Add("nodeId", NodeID);
-
-            string RequestPL = Newtonsoft.Json.JsonConvert.SerializeObject(Request);
-            _driver.ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
+            return _driver.SendRequestAsync(request);
         }
 
         // Checked as of : 3.5.0
         public Task<CMDResult> BeginRebuildingRoutes(RebuildRoutesOptions Options)
         {
-            Guid ID = Guid.NewGuid();
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
+            var request = new Dictionary<string, object>
+            {
+                { "command", Enums.Commands.BeginRebuildingRoutes },
+                { "options", Options }
+            };
 
-            _driver.Callbacks.Add(ID, (JO) =>
-             {
-                 CMDResult Res = new CMDResult(JO);
-                 if (Res.Success && Res.ResultPayloadAs<bool>())
-                 {
-                     this.isRebuildingRoutes = true;
-                 }
-                 Result.SetResult(Res);
-             });
-
-            Dictionary<string, object> Request = new Dictionary<string, object>();
-
-            Request.Add("messageId", ID);
-            Request.Add("command", Enums.Commands.BeginRebuildingRoutes);
-            Request.Add("options", Options);
-
-            string RequestPL = Newtonsoft.Json.JsonConvert.SerializeObject(Request);
-            _driver.ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
+            return _driver.SendRequestAsync(request, (JO, Res) =>
+            {
+                if (Res.Success && Res.ResultPayloadAs<bool>())
+                {
+                    this.isRebuildingRoutes = true;
+                }
+            });
         }
 
         // Checked as of : 3.5.0
         public Task<CMDResult> StopRebuildingRoutes()
         {
-            Guid ID = Guid.NewGuid();
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
+            var request = new Dictionary<string, object>
+            {
+                { "command", Enums.Commands.StopRebuildingRoutes }
+            };
 
-            _driver.Callbacks.Add(ID, (JO) =>
-             {
-                 CMDResult Res = new CMDResult(JO);
-                 if (Res.Success && Res.ResultPayloadAs<bool>())
-                 {
-                     this.isRebuildingRoutes = false;
-                 }
-
-                 Result.SetResult(Res);
-             });
-
-            Dictionary<string, object> Request = new Dictionary<string, object>();
-
-            Request.Add("messageId", ID);
-            Request.Add("command", Enums.Commands.StopRebuildingRoutes);
-
-            string RequestPL = Newtonsoft.Json.JsonConvert.SerializeObject(Request);
-            _driver.ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
+            return _driver.SendRequestAsync(request, (JO, Res) =>
+            {
+                if (Res.Success && Res.ResultPayloadAs<bool>())
+                {
+                    this.isRebuildingRoutes = false;
+                }
+            });
         }
 
         // Checked as of : 3.5.0
@@ -830,9 +579,6 @@ namespace ZWaveJS.NET
             ValidateDSKAndEnterPINSub = null;
             GrantSecurityClassesSub = null;
             AbortSub = null;
-
-            Guid ID = Guid.NewGuid();
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
 
             switch (Options.strategy)
             {
@@ -850,15 +596,13 @@ namespace ZWaveJS.NET
                 if (ValidateDSKAndEnterPINSub == null || GrantSecurityClassesSub == null || AbortSub == null)
                 {
                     CMDResult Res = new CMDResult(Enums.ErrorCodes.MissingS2Callbacks, "S2 Security require userCallbacks to be provided [validateDSKAndEnterPIN, grantSecurityClasses, abort]", false);
-                    Result.SetResult(Res);
-                    return Result.Task;
+                    return Task.FromResult(Res);
                 }
 
                 if (_driver.Options != null && _driver.Options.MissingKeys(true, true))
                 {
                     CMDResult Res = new CMDResult(Enums.ErrorCodes.MissingKeys, "Missing Security Keys in Options", false);
-                    Result.SetResult(Res);
-                    return Result.Task;
+                    return Task.FromResult(Res);
                 }
             }
 
@@ -868,15 +612,13 @@ namespace ZWaveJS.NET
                 if (ValidateDSKAndEnterPINSub == null || GrantSecurityClassesSub == null || AbortSub == null)
                 {
                     CMDResult Res = new CMDResult(Enums.ErrorCodes.MissingS2Callbacks, "S2 Security require userCallbacks to be provided [validateDSKAndEnterPIN, grantSecurityClasses, abort]", false);
-                    Result.SetResult(Res);
-                    return Result.Task;
+                    return Task.FromResult(Res);
                 }
 
                 if (_driver.Options != null && _driver.Options.MissingKeys(true, false))
                 {
                     CMDResult Res = new CMDResult(Enums.ErrorCodes.MissingKeys, "Missing Security Keys in Options", false);
-                    Result.SetResult(Res);
-                    return Result.Task;
+                    return Task.FromResult(Res);
                 }
             }
 
@@ -885,79 +627,55 @@ namespace ZWaveJS.NET
                 if (_driver.Options != null && _driver.Options.MissingKeys(false, true))
                 {
                     CMDResult Res = new CMDResult(Enums.ErrorCodes.MissingKeys, "Missing Security Keys in Options", false);
-                    Result.SetResult(Res);
-                    return Result.Task;
+                    return Task.FromResult(Res);
                 }
             }
             
             if (_driver.Options != null && !_driver.Options.CheckKeyLength())
             {
                 CMDResult Res = new CMDResult(Enums.ErrorCodes.InvalidkeyLength, "Invalid Key length. All Security Keys must be a 32 character hexadecimal string (representing 16 bytes)", false);
-                Result.SetResult(Res);
-                return Result.Task;
+                return Task.FromResult(Res);
             }
 
-            _driver.Callbacks.Add(ID, (JO) =>
-             {
-                 CMDResult Res = new CMDResult(JO);
-                 Result.SetResult(Res);
-             });
+            var optionsDict = new Dictionary<string, object>
+            {
+                { "strategy", (int)Options.strategy },
+                { "forceSecurity", Options.forceSecurity }
+            };
 
-            Dictionary<string, object> _Options = new Dictionary<string, object>();
-            _Options.Add("strategy", (int)Options.strategy);
-            _Options.Add("forceSecurity", Options.forceSecurity);
+            var request = new Dictionary<string, object>
+            {
+                { "command", Enums.Commands.BeginInclusion },
+                { "options", optionsDict }
+            };
 
-            Dictionary<string, object> Request = new Dictionary<string, object>();
-            Request.Add("messageId", ID);
-            Request.Add("command", Enums.Commands.BeginInclusion);
-            Request.Add("options", _Options);
-
-            string RequestPL = Newtonsoft.Json.JsonConvert.SerializeObject(Request);
-            _driver.ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
+            return _driver.SendRequestAsync(request);
         }
 
         // Checked as of : 3.5.0
         public Task<CMDResult> StopInclusion()
         {
-            Guid ID = Guid.NewGuid();
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
+            var request = new Dictionary<string, object>
+            {
+                { "command", Enums.Commands.StopInclusion }
+            };
 
-            _driver.Callbacks.Add(ID, (JO) =>
-             {
-                 CMDResult Res = new CMDResult(JO);
-                 Result.SetResult(Res);
-             });
-
-            Dictionary<string, object> Request = new Dictionary<string, object>();
-            Request.Add("messageId", ID);
-            Request.Add("command", Enums.Commands.StopInclusion);
-
-            string RequestPL = Newtonsoft.Json.JsonConvert.SerializeObject(Request);
-            _driver.ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
+            return _driver.SendRequestAsync(request);
         }
-        
+
         // Checked as of : 3.5.0
         public Task<CMDResult> ProvisionSmartStartNode(SmartStartProvisioningEntry ProvisioningInformation)
         {
-            Guid ID = Guid.NewGuid();
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
-
             if (_driver.Options != null && _driver.Options.MissingKeys(true, true))
             {
                 CMDResult Res = new CMDResult(Enums.ErrorCodes.MissingKeys, "Missing Security Keys in Options", false);
-                Result.SetResult(Res);
-                return Result.Task;
+                return Task.FromResult(Res);
             }
 
             if (_driver.Options != null && !_driver.Options.CheckKeyLength())
             {
                 CMDResult Res = new CMDResult(Enums.ErrorCodes.InvalidkeyLength, "Invalid Key length. All Security Keys must be a 32 character hexadecimal string (representing 16 bytes)", false);
-                Result.SetResult(Res);
-                return Result.Task;
+                return Task.FromResult(Res);
             }
 
             if (ProvisioningInformation.protocol == Protocols.ZWaveLongRange)
@@ -965,106 +683,59 @@ namespace ZWaveJS.NET
                 if (_driver.Options != null && _driver.Options.MissingLRKeys())
                 {
                     CMDResult Res = new CMDResult(Enums.ErrorCodes.MissingKeys, "Missing LR Security Keys in Options", false);
-                    Result.SetResult(Res);
-                    return Result.Task;
+                    return Task.FromResult(Res);
                 }
 
 
                 if (_driver.Options != null && !_driver.Options.CheckKeyLengthLR())
                 {
                     CMDResult Res = new CMDResult(Enums.ErrorCodes.InvalidkeyLength, "Invalid Key length. All Security Keys must be a 32 character hexadecimal string (representing 16 bytes)", false);
-                    Result.SetResult(Res);
-                    return Result.Task;
+                    return Task.FromResult(Res);
                 }
             }
 
-            _driver.Callbacks.Add(ID, (JO) =>
+            var request = new Dictionary<string, object>
             {
-                CMDResult Res = new CMDResult(JO);
-                Result.SetResult(Res);
-            });
+                { "command", Enums.Commands.ProvisionSmartStartNode },
+                { "entry", ProvisioningInformation }
+            };
 
-            Dictionary<string, object> Request = new Dictionary<string, object>();
-
-            Request.Add("messageId", ID);
-            Request.Add("command", Enums.Commands.ProvisionSmartStartNode);
-            Request.Add("entry", ProvisioningInformation);
-
-            string RequestPL = Newtonsoft.Json.JsonConvert.SerializeObject(Request);
-            _driver.ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
+            return _driver.SendRequestAsync(request);
         }
 
         // Checked as of : 3.5.0
         public Task<CMDResult> BeginExclusion(ExclusionOptions Options)
         {
-            Guid ID = Guid.NewGuid();
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
+            var request = new Dictionary<string, object>
+            {
+                { "command", Enums.Commands.BeginExclusion },
+                { "options", Options }
+            };
 
-            _driver.Callbacks.Add(ID, (JO) =>
-             {
-                 CMDResult Res = new CMDResult(JO);
-                 Result.SetResult(Res);
-             });
-
-            Dictionary<string, object> Request = new Dictionary<string, object>();
-
-            Request.Add("messageId", ID);
-            Request.Add("command", Enums.Commands.BeginExclusion);
-            Request.Add("options", Options);
-
-            string RequestPL = Newtonsoft.Json.JsonConvert.SerializeObject(Request);
-            _driver.ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
+            return _driver.SendRequestAsync(request);
         }
 
         // Checked as of : 3.5.0
         public Task<CMDResult> StopExclusion()
         {
-            Guid ID = Guid.NewGuid();
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
+            var request = new Dictionary<string, object>
+            {
+                { "command", Enums.Commands.StopExclusion }
+            };
 
-            _driver.Callbacks.Add(ID, (JO) =>
-             {
-                 CMDResult Res = new CMDResult(JO);
-                 Result.SetResult(Res);
-             });
-
-            Dictionary<string, object> Request = new Dictionary<string, object>();
-
-            Request.Add("messageId", ID);
-            Request.Add("command", Enums.Commands.StopExclusion);
-
-            string RequestPL = Newtonsoft.Json.JsonConvert.SerializeObject(Request);
-            _driver.ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
+            return _driver.SendRequestAsync(request);
         }
         
         // Checked as of : 3.5.0
         private Task<CMDResult> _UnprovisionSmartStartNode(object dskOrNodeId)
         {
-            Guid ID = Guid.NewGuid();
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
-
-            _driver.Callbacks.Add(ID, (JO) =>
+            var request = new Dictionary<string, object>
             {
-                CMDResult Res = new CMDResult(JO);
-                Result.SetResult(Res);
-            });
+                { "command", Enums.Commands.UnprovisionSmartStartNode },
+                { "dskOrNodeId", dskOrNodeId }
+            };
 
-            Dictionary<string, object> Request = new Dictionary<string, object>();
-
-            Request.Add("messageId", ID);
-            Request.Add("command", Enums.Commands.UnprovisionSmartStartNode);
-            Request.Add("dskOrNodeId", dskOrNodeId);
-
-            string RequestPL = Newtonsoft.Json.JsonConvert.SerializeObject(Request);
-            _driver.ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
+            return _driver.SendRequestAsync(request);
         }
         
         // LOCAL

--- a/Visual Studio Projects/ZWaveJS.NET/ZWaveJS.NET/Driver.cs
+++ b/Visual Studio Projects/ZWaveJS.NET/ZWaveJS.NET/Driver.cs
@@ -371,7 +371,7 @@ namespace ZWaveJS.NET
             ControllerEventMap.Add("statistics updated", (JO) =>
             {
                 ControllerStatisticsUpdatedArgs CS = JO.SelectToken("event.statistics").ToObject<ControllerStatisticsUpdatedArgs>();
-               
+              
                 Task.Run(() =>
                 {
                     this.Controller.Trigger_StatisticsUpdated(CS);
@@ -471,13 +471,13 @@ namespace ZWaveJS.NET
                      InclusionGrant RIG = JO.SelectToken("event.requested").ToObject<InclusionGrant>();
                      InclusionGrant SIG = this.Controller.Trigger_GrantSecurityClasses(RIG);
 
-                     Dictionary<string, object> Request = new Dictionary<string, object>();
-                     Request.Add("messageId", Guid.NewGuid().ToString());
-                     Request.Add("command", Enums.Commands.GrantSecurityClasses);
-                     Request.Add("inclusionGrant", SIG);
+                     var request = new Dictionary<string, object>
+                     {
+                         { "command", Enums.Commands.GrantSecurityClasses },
+                         { "inclusionGrant", SIG }
+                     };
 
-                     string RequestPL = Newtonsoft.Json.JsonConvert.SerializeObject(Request);
-                     ClientWebSocket.SendInstant(RequestPL);
+                     _ = SendRequestAsync(request);
                  });
 
             });
@@ -488,13 +488,13 @@ namespace ZWaveJS.NET
                 {
                     string DSK = this.Controller.Trigger_ValidateDSK(JO.SelectToken("event.dsk").ToObject<string>());
 
-                    Dictionary<string, object> Request = new Dictionary<string, object>();
-                    Request.Add("messageId", Guid.NewGuid().ToString());
-                    Request.Add("command", Enums.Commands.ValidateDSK);
-                    Request.Add("pin", DSK);
+                    var request = new Dictionary<string, object>
+                    {
+                        { "command", Enums.Commands.ValidateDSK },
+                        { "pin", DSK }
+                    };
 
-                    string RequestPL = Newtonsoft.Json.JsonConvert.SerializeObject(Request);
-                    ClientWebSocket.SendInstant(RequestPL);
+                    _ = SendRequestAsync(request);
                 });
             });
 
@@ -802,16 +802,13 @@ namespace ZWaveJS.NET
         {
             if (JO.Value<bool>("success"))
             {
-                Guid CBID = Guid.NewGuid();
-                Callbacks.Add(CBID, StartListetningCB);
+                var request = new Dictionary<string, object>
+                {
+                    { "command", Enums.Commands.StartListetning }
+                };
 
-                Dictionary<string, object> Request = new Dictionary<string, object>();
-                Request.Add("messageId", CBID.ToString());
-                Request.Add("command", Enums.Commands.StartListetning);
-
-                string RequestPL = Newtonsoft.Json.JsonConvert.SerializeObject(Request);
-
-                ClientWebSocket.SendInstant(RequestPL);
+                // fire-and-forget; StartListetningCB will be invoked when response arrives
+                _ = SendRequestAsync(request, (respJO, res) => StartListetningCB(respJO));
             }
             else
             {
@@ -857,96 +854,52 @@ namespace ZWaveJS.NET
 
         public Task<CMDResult> ZWJSS_StartListeningLogs()
         {
-            Guid ID = Guid.NewGuid();
-
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
-
-            Callbacks.Add(ID, (JO) =>
+            var request = new Dictionary<string, object>
             {
-                CMDResult Res = new CMDResult(JO);
-                Result.SetResult(Res);
-            });
+                { "command", Enums.Commands.StartListeningLogs }
+            };
 
-            Dictionary<string, object> Request = new Dictionary<string, object>();
-
-            Request.Add("messageId", ID);
-            Request.Add("command", Enums.Commands.StartListeningLogs);
-
-            string RequestPL = Newtonsoft.Json.JsonConvert.SerializeObject(Request);
-            ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
+            return SendRequestAsync(request);
         }
 
         public Task<CMDResult> ZWJSS_StopListeningLogs()
         {
-            Guid ID = Guid.NewGuid();
-
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
-
-            Callbacks.Add(ID, (JO) =>
+            var request = new Dictionary<string, object>
             {
-                CMDResult Res = new CMDResult(JO);
-                Result.SetResult(Res);
-            });
+                { "command", Enums.Commands.StopListeningLogs }
+            };
 
-            Dictionary<string, object> Request = new Dictionary<string, object>();
-
-            Request.Add("messageId", ID);
-            Request.Add("command", Enums.Commands.StopListeningLogs);
-
-            string RequestPL = Newtonsoft.Json.JsonConvert.SerializeObject(Request);
-            ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
+            return SendRequestAsync(request);
         }
 
         public Task<CMDResult> HardReset()
         {
-            Guid ID = Guid.NewGuid();
-
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
-
-            Callbacks.Add(ID, (JO) =>
+            var request = new Dictionary<string, object>
             {
-                CMDResult Res = new CMDResult(JO);
-                Result.SetResult(Res);
+                { "command", Enums.Commands.HardReset }
+            };
 
-                Restart();
+            return SendRequestAsync(request, (JO, Res) =>
+            {
+                try
+                {
+                    Restart();
+                }
+                catch
+                {
+                    // swallow to avoid breaking completion
+                }
             });
-
-            Dictionary<string, object> Request = new Dictionary<string, object>();
-
-            Request.Add("messageId", ID);
-            Request.Add("command", Enums.Commands.HardReset);
-
-            string RequestPL = Newtonsoft.Json.JsonConvert.SerializeObject(Request);
-            ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
         }
 
         public Task<CMDResult> SoftReset()
         {
-            Guid ID = Guid.NewGuid();
-
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
-
-            Callbacks.Add(ID, (JO) =>
+            var request = new Dictionary<string, object>
             {
-                CMDResult Res = new CMDResult(JO);
-                Result.SetResult(Res);
-            });
+                { "command", Enums.Commands.SoftReset }
+            };
 
-            Dictionary<string, object> Request = new Dictionary<string, object>();
-
-            Request.Add("messageId", ID);
-            Request.Add("command", Enums.Commands.SoftReset);
-
-            string RequestPL = Newtonsoft.Json.JsonConvert.SerializeObject(Request);
-            ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
+            return SendRequestAsync(request);
         }
 
         // Proces Message
@@ -989,17 +942,13 @@ namespace ZWaveJS.NET
                     _ZWaveJSDriverVersion = JO.Value<string>("driverVersion");
                     _ZWaveJSServerVersion = JO.Value<string>("serverVersion");
 
-                    Guid CBID = Guid.NewGuid();
-                    Callbacks.Add(CBID, SetAPIVersionCB);
+                    var request = new Dictionary<string, object>
+                    {
+                        { "command", Enums.Commands.SetAPIVersion },
+                        { "schemaVersion", _schemaVersion }
+                    };
 
-                    Dictionary<string, object> Request = new Dictionary<string, object>();
-                    Request.Add("messageId", CBID.ToString());
-                    Request.Add("command", Enums.Commands.SetAPIVersion);
-                    Request.Add("schemaVersion", _schemaVersion);
-
-                    string RequestPL = Newtonsoft.Json.JsonConvert.SerializeObject(Request);
-
-                    ClientWebSocket.SendInstant(RequestPL);
+                    _ = SendRequestAsync(request, (respJO, res) => SetAPIVersionCB(respJO));
 
                     return;
                 }
@@ -1038,5 +987,77 @@ namespace ZWaveJS.NET
             }
         }
 
+        internal Task<CMDResult> SendRequestAsync(
+            Dictionary<string, object> request,
+            Action<JObject, CMDResult> mapResult = null,
+            TimeSpan? timeout = null)
+        {
+            Guid id = Guid.NewGuid();
+            request["messageId"] = id;
+
+            var tcs = new TaskCompletionSource<CMDResult>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            // Register callback
+            Callbacks.Add(id, (JO) =>
+            {
+                try
+                {
+                    var res = new CMDResult(JO);
+                    try
+                    {
+                        mapResult?.Invoke(JO, res);
+                    }
+                    catch (Exception exMap)
+                    {
+                        // if mapping throws, surface it
+                        tcs.TrySetException(exMap);
+                        return;
+                    }
+
+                    tcs.TrySetResult(res);
+                }
+                catch (Exception ex)
+                {
+                    tcs.TrySetException(ex);
+                }
+                finally
+                {
+                    // best-effort cleanup
+                    try { Callbacks.Remove(id); } catch { }
+                }
+            });
+
+            string payload = Newtonsoft.Json.JsonConvert.SerializeObject(request);
+
+            try
+            {
+                var sendTask = ClientWebSocket.SendInstant(payload);
+                sendTask.ContinueWith(t =>
+                {
+                    if (t.IsFaulted)
+                    {
+                        tcs.TrySetException(t.Exception?.GetBaseException() ?? new Exception("SendInstant failed"));
+                        try { Callbacks.Remove(id); } catch { }
+                    }
+                }, TaskContinuationOptions.ExecuteSynchronously);
+            }
+            catch (Exception ex)
+            {
+                tcs.TrySetException(ex);
+                try { Callbacks.Remove(id); } catch { }
+            }
+
+            if (timeout.HasValue)
+            {
+                var cts = new System.Threading.CancellationTokenSource(timeout.Value);
+                cts.Token.Register(() =>
+                {
+                    tcs.TrySetException(new TimeoutException("Request timed out"));
+                    try { Callbacks.Remove(id); } catch { }
+                });
+            }
+
+            return tcs.Task;
+        }
     }
 }

--- a/Visual Studio Projects/ZWaveJS.NET/ZWaveJS.NET/Endpoint.cs
+++ b/Visual Studio Projects/ZWaveJS.NET/ZWaveJS.NET/Endpoint.cs
@@ -17,67 +17,44 @@ namespace ZWaveJS.NET
         // Checked as of : 3.5.0
         public Task<CMDResult> SupportsCCAPI(int CommandClass)
         {
-            Guid ID = Guid.NewGuid();
-
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
-            _driver.Callbacks.Add(ID, (JO) =>
+            var request = new Dictionary<string, object>
             {
-                CMDResult Res = new CMDResult(JO);
+                { "command", Enums.Commands.SupportsCCAPI },
+                { "nodeId", this.nodeId },
+                { "endpoint", this.index },
+                { "commandClass", CommandClass }
+            };
+
+            return _driver.SendRequestAsync(request, (JO, Res) =>
+            {
                 if (Res.Success)
                 {
                     Res.SetPayload(JO.SelectToken("result.supported").ToObject<bool>());
                 }
-                Result.SetResult(Res);
-
-              
             });
-
-            Dictionary<string, object> Request = new Dictionary<string, object>();
-            Request.Add("messageId", ID);
-            Request.Add("command", Enums.Commands.SupportsCCAPI);
-            Request.Add("nodeId", this.nodeId);
-            Request.Add("endpoint", this.index);
-            Request.Add("commandClass", CommandClass);
-
-            string RequestPL = JsonConvert.SerializeObject(Request);
-            _driver.ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
         }
 
 
         // Checked as of : 3.5.0
         public Task<CMDResult> InvokeCCAPI(int CommandClass, string Method, params object[] Params)
         {
-            Guid ID = Guid.NewGuid();
-
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
-            _driver.Callbacks.Add(ID, (JO) =>
+            var request = new Dictionary<string, object>
             {
-                CMDResult Res = new CMDResult(JO);
+                { "command", Enums.Commands.InvokeCCAPI },
+                { "nodeId", this.nodeId },
+                { "endpoint", this.index },
+                { "commandClass", CommandClass },
+                { "methodName", Method },
+                { "args", Params }
+            };
+
+            return _driver.SendRequestAsync(request, (JO, Res) =>
+            {
                 if (Res.Success)
                 {
                     Res.SetPayload(JO.SelectToken("result").ToObject<JObject>());
                 }
-                Result.SetResult(Res);
-
-
             });
-
-            Dictionary<string, object> Request = new Dictionary<string, object>();
-            Request.Add("messageId", ID);
-            Request.Add("command", Enums.Commands.InvokeCCAPI);
-            Request.Add("nodeId", this.nodeId);
-            Request.Add("endpoint", this.index);
-            Request.Add("commandClass", CommandClass);
-            Request.Add("methodName", Method);
-            Request.Add("args", Params);
-
-
-            string RequestPL = JsonConvert.SerializeObject(Request);
-            _driver.ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
         }
 
         [Newtonsoft.Json.JsonProperty]

--- a/Visual Studio Projects/ZWaveJS.NET/ZWaveJS.NET/Endpoint.cs
+++ b/Visual Studio Projects/ZWaveJS.NET/ZWaveJS.NET/Endpoint.cs
@@ -57,6 +57,24 @@ namespace ZWaveJS.NET
             });
         }
 
+        public Task<CMDResult> GetCCs()
+        {
+            var request = new Dictionary<string, object>
+            {
+                { "command", Enums.Commands.GetCCs },
+                { "nodeId", this.nodeId },
+                { "endpoint", this.index }
+            };
+
+            return _driver.SendRequestAsync(request, (JO, Res) =>
+            {
+                if (Res.Success)
+                {
+                    Res.SetPayload(JO.SelectToken("result.commandClasses").ToObject<Dictionary<int, CommandClassInfo>>());
+                }
+            });
+        }
+
         [Newtonsoft.Json.JsonProperty]
         public int nodeId { get; internal set; }
         [Newtonsoft.Json.JsonProperty]

--- a/Visual Studio Projects/ZWaveJS.NET/ZWaveJS.NET/Enums.cs
+++ b/Visual Studio Projects/ZWaveJS.NET/ZWaveJS.NET/Enums.cs
@@ -180,6 +180,7 @@
             // ---------------- ENDPOINT ----------------
             public const string InvokeCCAPI = "endpoint.invoke_cc_api";
             public const string SupportsCCAPI = "endpoint.supports_cc_api";
+            public const string GetCCs = "endpoint.get_ccs";
 
             // ---------------- MULTICAST GROUP ----------------
             public const string MCGetEndpointCount = "multicast_group.get_endpoint_count";

--- a/Visual Studio Projects/ZWaveJS.NET/ZWaveJS.NET/MethodFactory.cs
+++ b/Visual Studio Projects/ZWaveJS.NET/ZWaveJS.NET/MethodFactory.cs
@@ -22,92 +22,53 @@ namespace ZWaveJS.NET
 
         public static Func<Dictionary<string, object>, Task<CMDResult>> CreateCLASS(Driver Runtime, string ServerMethod, Type MappedClass, string ObjectPath)
         {
-            return (x) => Execute(Runtime, ServerMethod, x,MappedClass, ObjectPath);
+            return (x) => Execute(Runtime, ServerMethod, x, MappedClass, ObjectPath);
         }
 
         private static Task<CMDResult> Execute(Driver Runtime, string ServerMethod, Dictionary<string, object> Args, string ObjectPath)
         {
-            Guid ID = Guid.NewGuid();
+            // create a shallow copy to avoid mutating caller dictionary
+            var request = new Dictionary<string, object>(Args ?? new Dictionary<string, object>());
 
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
+            // ensure command is set as expected by the server
+            request.Remove("messageId");
+            request["command"] = ServerMethod;
 
-            Runtime.Callbacks.Add(ID, (JO) =>
+            return Runtime.SendRequestAsync(request, (JO, Res) =>
             {
-                CMDResult Res = new CMDResult(JO);
                 if (Res.Success)
                 {
                     object Obj = JO.SelectToken(ObjectPath).ToObject<object>();
                     Res.SetPayload(Obj);
                 }
-                Result.SetResult(Res);
-
             });
-
-            Args.Remove("messageId");
-            Args.Remove("command");
-
-            Args.Add("messageId", ID);
-            Args.Add("command", ServerMethod);
-
-            string RequestPL = Newtonsoft.Json.JsonConvert.SerializeObject(Args);
-            Runtime.ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
         }
 
         private static Task<CMDResult> Execute(Driver Runtime, string ServerMethod, Dictionary<string, object> Args, Type MappedClass, string ObjectPath)
         {
-            Guid ID = Guid.NewGuid();
+            var request = new Dictionary<string, object>(Args ?? new Dictionary<string, object>());
 
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
+            request.Remove("messageId");
+            request["command"] = ServerMethod;
 
-            Runtime.Callbacks.Add(ID, (JO) =>
+            return Runtime.SendRequestAsync(request, (JO, Res) =>
             {
-                CMDResult Res = new CMDResult(JO);
                 if (Res.Success)
                 {
                     object Obj = JO.SelectToken(ObjectPath).ToObject(MappedClass);
                     Res.SetPayload(Obj);
                 }
-                Result.SetResult(Res);
-
             });
-
-            Args.Remove("messageId");
-            Args.Remove("command");
-
-            Args.Add("messageId", ID);
-            Args.Add("command", ServerMethod);
-
-            string RequestPL = Newtonsoft.Json.JsonConvert.SerializeObject(Args);
-            Runtime.ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
         }
 
         private static Task<CMDResult> Execute(Driver Runtime, string ServerMethod, Dictionary<string, object> Args)
         {
-            Guid ID = Guid.NewGuid();
+            var request = new Dictionary<string, object>(Args ?? new Dictionary<string, object>());
 
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
+            request.Remove("messageId");
+            request["command"] = ServerMethod;
 
-            Runtime.Callbacks.Add(ID, (JO) =>
-            {
-                CMDResult Res = new CMDResult(JO);
-                Result.SetResult(Res);
-
-            });
-
-            Args.Remove("messageId");
-            Args.Remove("command");
-            
-            Args.Add("messageId", ID);
-            Args.Add("command", ServerMethod);
-
-            string RequestPL = Newtonsoft.Json.JsonConvert.SerializeObject(Args);
-            Runtime.ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
+            return Runtime.SendRequestAsync(request);
         }
     }
 }

--- a/Visual Studio Projects/ZWaveJS.NET/ZWaveJS.NET/Structures.cs
+++ b/Visual Studio Projects/ZWaveJS.NET/ZWaveJS.NET/Structures.cs
@@ -47,7 +47,7 @@ namespace ZWaveJS.NET
         [Newtonsoft.Json.JsonProperty]
         public Enums.SetValueStatus status { get; internal set; }
         [Newtonsoft.Json.JsonProperty]
-        public string remainingDuration { get; internal set; }
+        public object remainingDuration { get; internal set; }
         [Newtonsoft.Json.JsonProperty]
         public string message { get; internal set; }
     }

--- a/Visual Studio Projects/ZWaveJS.NET/ZWaveJS.NET/Structures.cs
+++ b/Visual Studio Projects/ZWaveJS.NET/ZWaveJS.NET/Structures.cs
@@ -362,6 +362,20 @@ namespace ZWaveJS.NET
         public bool isSecure { get; internal set; }
     }
 
+    public class CommandClassInfo
+    {
+        internal CommandClassInfo() { }
+
+        [Newtonsoft.Json.JsonProperty]
+        public bool isSupported { get; internal set; }
+        [Newtonsoft.Json.JsonProperty]
+        public bool isControlled { get; internal set; }
+        [Newtonsoft.Json.JsonProperty]
+        public bool secure { get; internal set; }
+        [Newtonsoft.Json.JsonProperty]
+        public int version { get; internal set; }
+    }
+
     public class FirmwareVersion
     {
         internal FirmwareVersion() { }

--- a/Visual Studio Projects/ZWaveJS.NET/ZWaveJS.NET/Utils.cs
+++ b/Visual Studio Projects/ZWaveJS.NET/ZWaveJS.NET/Utils.cs
@@ -19,30 +19,20 @@ namespace ZWaveJS.NET
         // Checked as of : 3.5.0
         public Task<CMDResult> ParseQRCodeString(string QR)
         {
-            Guid ID = Guid.NewGuid();
-
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
-
-            _driver.Callbacks.Add(ID, (JO) =>
+            var request = new Dictionary<string, object>
             {
-                CMDResult Res = new CMDResult(JO);
+                { "command", Enums.Commands.ParseQRCodeString },
+                { "qr", QR }
+            };
+
+            return _driver.SendRequestAsync(request, (JO, Res) =>
+            {
                 if (Res.Success)
                 {
                     QRProvisioningInformation PQR = JO.SelectToken("result.qrProvisioningInformation").ToObject<QRProvisioningInformation>();
                     Res.SetPayload(PQR);
                 }
-                Result.SetResult(Res);
             });
-
-            Dictionary<string, object> Request = new Dictionary<string, object>();
-            Request.Add("messageId", ID);
-            Request.Add("command", Enums.Commands.ParseQRCodeString);
-            Request.Add("qr", QR);
-            
-            string RequestPL = Newtonsoft.Json.JsonConvert.SerializeObject(Request);
-            _driver.ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
         }
     }
 }

--- a/Visual Studio Projects/ZWaveJS.NET/ZWaveJS.NET/VirtualNode.cs
+++ b/Visual Studio Projects/ZWaveJS.NET/ZWaveJS.NET/VirtualNode.cs
@@ -17,152 +17,102 @@ namespace ZWaveJS.NET
         // Checked as of : 3.5.0
         public Task<CMDResult> GetEndpointCount()
         {
-            Guid ID = Guid.NewGuid();
-
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
-
-            _driver.Callbacks.Add(ID, (JO) =>
+            var request = new Dictionary<string, object>
             {
-                CMDResult Res = new CMDResult(JO);
+                { "command", Enums.Commands.MCGetEndpointCount },
+                { "nodeIDs", this.Nodes }
+            };
+
+            return _driver.SendRequestAsync(request, (JO, Res) =>
+            {
                 if (Res.Success)
                 {
                     Res.SetPayload(JO.SelectToken("result.count").ToObject<int>());
                 }
-                Result.SetResult(Res);
             });
-
-            Dictionary<string, object> Request = new Dictionary<string, object>();
-            Request.Add("messageId", ID);
-            Request.Add("command", Enums.Commands.MCGetEndpointCount);
-            Request.Add("nodeIDs", this.Nodes);
-
-            string RequestPL = JsonConvert.SerializeObject(Request);
-            _driver.ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
         }
 
         // Checked as of : 3.5.0
         public Task<CMDResult> SetValue(ValueID ValueID, object Value, SetValueAPIOptions Options = null)
         {
-            Guid ID = Guid.NewGuid();
-
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
-            _driver.Callbacks.Add(ID, (JO) =>
+            var request = new Dictionary<string, object>
             {
-                CMDResult Res = new CMDResult(JO);
+                { "command", Enums.Commands.MCSetValue },
+                { "nodeIDs", this.Nodes },
+                { "valueId", ValueID },
+                { "value", Value }
+            };
+
+            if (Options != null)
+            {
+                request.Add("options", Options);
+            }
+
+            return _driver.SendRequestAsync(request, (JO, Res) =>
+            {
                 if (Res.Success)
                 {
                     Res.SetPayload(JO.SelectToken("result.result").ToObject<SetValueResult>());
                 }
-                
             });
-
-            Dictionary<string, object> Request = new Dictionary<string, object>();
-            Request.Add("messageId", ID);
-            Request.Add("command", Enums.Commands.MCSetValue);
-            Request.Add("nodeIDs", this.Nodes);
-            Request.Add("valueId", ValueID);
-            Request.Add("value", Value);
-
-            if (Options != null)
-            {
-                Request.Add("options", Options);
-            }
-
-            string RequestPL = Newtonsoft.Json.JsonConvert.SerializeObject(Request);
-            _driver.ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
         }
 
         // Checked as of : 3.5.0
         public Task<CMDResult> GetDefinedValueIDs()
         {
-            Guid ID = Guid.NewGuid();
-
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
-            _driver.Callbacks.Add(ID, (JO) =>
+            var request = new Dictionary<string, object>
             {
-                CMDResult Res = new CMDResult(JO);
+                { "command", Enums.Commands.MCGetDefinedValueIDs },
+                { "nodeIDs", this.Nodes }
+            };
+
+            return _driver.SendRequestAsync(request, (JO, Res) =>
+            {
                 if (Res.Success)
                 {
                     Res.SetPayload(JO.SelectToken("result.valueIDs").ToObject<ValueID[]>());
                 }
-
-                Result.SetResult(Res);
             });
-
-            Dictionary<string, object> Request = new Dictionary<string, object>();
-            Request.Add("messageId", ID);
-            Request.Add("command", Enums.Commands.MCGetDefinedValueIDs);
-            Request.Add("nodeIDs", this.Nodes);
-
-
-            string RequestPL = JsonConvert.SerializeObject(Request);
-            _driver.ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
         }
 
         // Checked as of : 3.5.0
         public Task<CMDResult> SupportsCCAPI(int CommandClass)
         {
-            Guid ID = Guid.NewGuid();
-
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
-            _driver.Callbacks.Add(ID, (JO) =>
+            var request = new Dictionary<string, object>
             {
-                CMDResult Res = new CMDResult(JO);
+                { "command", Enums.Commands.MCSupportsCCAPI },
+                { "nodeIDs", this.Nodes },
+                { "commandClass", CommandClass }
+            };
+
+            return _driver.SendRequestAsync(request, (JO, Res) =>
+            {
                 if (Res.Success)
                 {
                     Res.SetPayload(JO.SelectToken("result.supported").ToObject<bool>());
-
                 }
-                Result.SetResult(Res);
             });
-
-            Dictionary<string, object> Request = new Dictionary<string, object>();
-            Request.Add("messageId", ID);
-            Request.Add("command", Enums.Commands.MCSupportsCCAPI);
-            Request.Add("nodeIDs", this.Nodes);
-            Request.Add("commandClass", CommandClass);
-
-            string RequestPL = JsonConvert.SerializeObject(Request);
-            _driver.ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
         }
-        
+
         // Checked as of : 3.5.0
         public Task<CMDResult> InvokeCCAPI(int CommandClass, string Method, params object[] Params)
         {
-            Guid ID = Guid.NewGuid();
-
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
-            _driver.Callbacks.Add(ID, (JO) =>
+            var request = new Dictionary<string, object>
             {
-                CMDResult Res = new CMDResult(JO);
+                { "command", Enums.Commands.MCInvokeCCAPI },
+                { "nodeIDs", this.Nodes },
+                { "commandClass", CommandClass },
+                { "methodName", Method },
+                { "args", Params }
+            };
+
+            return _driver.SendRequestAsync(request, (JO, Res) =>
+            {
                 if (Res.Success)
                 {
                     Res.SetPayload(JO.SelectToken("result").ToObject<JObject>());
                 }
-                Result.SetResult(Res);
-
             });
-
-            Dictionary<string, object> Request = new Dictionary<string, object>();
-            Request.Add("messageId", ID);
-            Request.Add("command", Enums.Commands.MCInvokeCCAPI);
-            Request.Add("nodeIDs", this.Nodes);
-            Request.Add("commandClass", CommandClass);
-            Request.Add("methodName", Method);
-            Request.Add("args", Params);
-
-            string RequestPL = JsonConvert.SerializeObject(Request);
-            _driver.ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
         }
 
         private int[] Nodes { get; set; }

--- a/Visual Studio Projects/ZWaveJS.NET/ZWaveJS.NET/ZWaveNode.cs
+++ b/Visual Studio Projects/ZWaveJS.NET/ZWaveJS.NET/ZWaveNode.cs
@@ -158,54 +158,31 @@ namespace ZWaveJS.NET
         // Checked as of : 3.5.0
         public Task<CMDResult> Ping()
         {
-            Guid ID = Guid.NewGuid();
-
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
-            _driver.Callbacks.Add(ID, (JO) =>
+            var request = new Dictionary<string, object>
             {
-                CMDResult Res = new CMDResult(JO);
+                { "command", Enums.Commands.Ping },
+                { "nodeId", this.id }
+            };
+
+            return _driver.SendRequestAsync(request, (JO, Res) =>
+            {
                 if (Res.Success)
                 {
                     Res.SetPayload(JO.SelectToken("result.responded").ToObject<bool>());
                 }
-                
-                Result.SetResult(Res);
             });
-
-            Dictionary<string, object> Request = new Dictionary<string, object>();
-            Request.Add("messageId", ID);
-            Request.Add("command", Enums.Commands.Ping);
-            Request.Add("nodeId", this.id);
-
-
-            string RequestPL = Newtonsoft.Json.JsonConvert.SerializeObject(Request);
-            _driver.ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
         }
 
         // Checked as of : 3.5.0
         public Task<CMDResult> Interview()
         {
-            Guid ID = Guid.NewGuid();
-
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
-            _driver.Callbacks.Add(ID, (JO) =>
+            var request = new Dictionary<string, object>
             {
-                CMDResult Res = new CMDResult(JO);
-                Result.SetResult(Res);
-            });
+                { "command", Enums.Commands.Interview },
+                { "nodeId", this.id }
+            };
 
-            Dictionary<string, object> Request = new Dictionary<string, object>();
-            Request.Add("messageId", ID);
-            Request.Add("command", Enums.Commands.Interview);
-            Request.Add("nodeId", this.id);
-
-
-            string RequestPL = Newtonsoft.Json.JsonConvert.SerializeObject(Request);
-            _driver.ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
+            return _driver.SendRequestAsync(request);
         }
         
         // Checked as of : 3.5.0
@@ -213,468 +190,287 @@ namespace ZWaveJS.NET
         {
             LifelineHealthCheckProgressSub = OnProgress;
 
-            Guid ID = Guid.NewGuid();
-
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
-            _driver.Callbacks.Add(ID, (JO) =>
+            var request = new Dictionary<string, object>
             {
-                CMDResult Res = new CMDResult(JO);
+                { "command", Enums.Commands.CheckLifelineHealth },
+                { "nodeId", this.id },
+                { "rounds", Rounds }
+            };
+
+            return _driver.SendRequestAsync(request, (JO, Res) =>
+            {
                 if (Res.Success)
                 {
                     LifelineHealthCheckSummary LLHCS = JO.SelectToken("result.summary").ToObject<LifelineHealthCheckSummary>();
                     Res.SetPayload(LLHCS);
                 }
-                
-                Result.SetResult(Res);
             });
-
-            Dictionary<string, object> Request = new Dictionary<string, object>();
-            Request.Add("messageId", ID);
-            Request.Add("command", Enums.Commands.CheckLifelineHealth);
-            Request.Add("nodeId", this.id);
-            Request.Add("rounds", Rounds);
-
-
-            string RequestPL = Newtonsoft.Json.JsonConvert.SerializeObject(Request);
-            _driver.ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
         }
 
         // Checked as of : 3.5.0
         public Task<CMDResult> AbortFirmwareUpdate()
         {
-            Guid ID = Guid.NewGuid();
-
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
-            _driver.Callbacks.Add(ID, (JO) =>
+            var request = new Dictionary<string, object>
             {
-                CMDResult Res = new CMDResult(JO);
-                Result.SetResult(Res);
-            });
+                { "command", Enums.Commands.AbortFirmwareUpdate },
+                { "nodeId", this.id }
+            };
 
-            Dictionary<string, object> Request = new Dictionary<string, object>();
-            Request.Add("messageId", ID);
-            Request.Add("command", Enums.Commands.AbortFirmwareUpdate);
-            Request.Add("nodeId", this.id);
-          
-
-            string RequestPL = Newtonsoft.Json.JsonConvert.SerializeObject(Request);
-            _driver.ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
+            return _driver.SendRequestAsync(request);
         }
 
         // Checked as of : 3.5.0
         public Task<CMDResult> UpdateFirmware(FirmwareUpdate[] Updates)
         {
-
             foreach(FirmwareUpdate FWU in Updates)
             {
                 if(FWU.firmwareTarget == null)
                 {
-                    TaskCompletionSource<CMDResult> Fail = new TaskCompletionSource<CMDResult>();
                     CMDResult Res = new CMDResult(Enums.ErrorCodes.WrongOverride, "Please use the override that includes 'firmwareTarget'", false);
-                    Fail.SetResult(Res);
-
-                    return Fail.Task;
+                    return Task.FromResult(Res);
                 }
             }
 
-            Guid ID = Guid.NewGuid();
-
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
-            _driver.Callbacks.Add(ID, (JO) =>
+            var request = new Dictionary<string, object>
             {
-                CMDResult Res = new CMDResult(JO);
+                { "command", Enums.Commands.UpdateFirmware },
+                { "nodeId", this.id },
+                { "updates", Updates }
+            };
+
+            return _driver.SendRequestAsync(request, (JO, Res) =>
+            {
                 if (Res.Success)
                 {
                     Res.SetPayload(JO.SelectToken("result.result").ToObject<NodeFirmwareUpdateResultArgs>());
                 }
-                
-                Result.SetResult(Res);
             });
-            
-            Dictionary<string, object> Request = new Dictionary<string, object>();
-            Request.Add("messageId", ID);
-            Request.Add("command", Enums.Commands.UpdateFirmware);
-            Request.Add("nodeId", this.id);
-            Request.Add("updates", Updates);
-            
-            string RequestPL = Newtonsoft.Json.JsonConvert.SerializeObject(Request);
-            _driver.ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
         }
 
         // Checked as of : 3.5.0
         public Task<CMDResult> RefreshInfo(RefreshInfoOptions Options = null)
         {
-            Guid ID = Guid.NewGuid();
-
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
-            _driver.Callbacks.Add(ID, (JO) =>
+            var request = new Dictionary<string, object>
             {
-                CMDResult Res = new CMDResult(JO);
-                Result.SetResult(Res);
-            });
+                { "command", Enums.Commands.RefreshInfo },
+                { "nodeId", this.id }
+            };
 
-            Dictionary<string, object> Request = new Dictionary<string, object>();
-            Request.Add("messageId", ID);
-            Request.Add("command", Enums.Commands.RefreshInfo);
-            Request.Add("nodeId", this.id);
+            if (Options != null)
+                request.Add("options", Options);
 
-            if(Options != null)
-                Request.Add("options", Options);
-
-            string RequestPL = Newtonsoft.Json.JsonConvert.SerializeObject(Request);
-            _driver.ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
+            return _driver.SendRequestAsync(request);
         }
 
         // Checked as of : 3.5.0
         public Task<CMDResult> GetValue(ValueID ValueID)
         {
-            Guid ID = Guid.NewGuid();
-
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
-            _driver.Callbacks.Add(ID, (JO) =>
+            var request = new Dictionary<string, object>
             {
-                CMDResult Res = new CMDResult(JO);
+                { "command", Enums.Commands.GetValue },
+                { "valueId", ValueID },
+                { "nodeId", this.id }
+            };
+
+            return _driver.SendRequestAsync(request, (JO, Res) =>
+            {
                 if (Res.Success)
                 {
                     Res.SetPayload(JO.SelectToken("result").ToObject<JObject>());
                 }
-
-                Result.SetResult(Res);
-
             });
-
-            Dictionary<string, object> Request = new Dictionary<string, object>();
-            Request.Add("messageId", ID);
-            Request.Add("command", Enums.Commands.GetValue);
-            Request.Add("valueId", ValueID);
-            Request.Add("nodeId", this.id);
-
-            string RequestPL = Newtonsoft.Json.JsonConvert.SerializeObject(Request);
-            _driver.ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
         }
 
         // Checked as of : 3.5.0
         public Task<CMDResult> SetValue(ValueID ValueID, object Value, SetValueAPIOptions Options = null)
         {
-            Guid ID = Guid.NewGuid();
-
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
-            _driver.Callbacks.Add(ID, (JO) =>
+            var request = new Dictionary<string, object>
             {
-                CMDResult Res = new CMDResult(JO);
+                { "command", Enums.Commands.SetValue },
+                { "nodeId", this.id },
+                { "valueId", ValueID },
+                { "value", Value }
+            };
+
+            if (Options != null)
+            {
+                request.Add("options", Options);
+            }
+
+            return _driver.SendRequestAsync(request, (JO, Res) =>
+            {
                 if (Res.Success)
                 {
                     SetValueResult SVR = JO.SelectToken("result.result").ToObject<SetValueResult>();
                     Res.SetPayload(SVR);
                 }
-                Result.SetResult(Res);
             });
-
-            Dictionary<string, object> Request = new Dictionary<string, object>();
-            Request.Add("messageId", ID);
-            Request.Add("command", Enums.Commands.SetValue);
-            Request.Add("nodeId", this.id);
-            Request.Add("valueId", ValueID);
-            Request.Add("value", Value);
-
-            if (Options != null)
-            {
-                Request.Add("options", Options);
-            }
-
-            string RequestPL = Newtonsoft.Json.JsonConvert.SerializeObject(Request);
-            _driver.ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
         }
 
         // Checked as of : 3.5.0
         public Task<CMDResult> PollValue(ValueID ValueID)
         {
-            Guid ID = Guid.NewGuid();
-
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
-            _driver.Callbacks.Add(ID, (JO) =>
+            var request = new Dictionary<string, object>
             {
-                CMDResult Res = new CMDResult(JO);
+                { "command", Enums.Commands.PollValue },
+                { "nodeId", this.id },
+                { "valueId", ValueID }
+            };
+
+            return _driver.SendRequestAsync(request, (JO, Res) =>
+            {
                 if (Res.Success)
                 {
                     Res.SetPayload(JO.SelectToken("result").ToObject<JObject>());
                 }
-
-                Result.SetResult(Res);
             });
-
-            Dictionary<string, object> Request = new Dictionary<string, object>();
-            Request.Add("messageId", ID);
-            Request.Add("command", Enums.Commands.PollValue);
-            Request.Add("nodeId", this.id);
-            Request.Add("valueId", ValueID);
-
-            string RequestPL = Newtonsoft.Json.JsonConvert.SerializeObject(Request);
-            _driver.ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
         }
 
         // Checked as of : 3.5.0 - Variant 1: Normal parameter, defined in a config file
         public Task<CMDResult> ZWJSS_SetRawConfigParameterValue(int Parameter, int Value)
         {
-            Guid ID = Guid.NewGuid();
-
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
-            _driver.Callbacks.Add(ID, (JO) =>
+            var request = new Dictionary<string, object>
             {
-                CMDResult Res = new CMDResult(JO);
-                Result.SetResult(Res);
-            });
+                { "command", Enums.Commands.SetRawConfigParameterValue },
+                { "nodeId", this.id },
+                { "parameter", Parameter },
+                { "value", Value }
+            };
 
-            Dictionary<string, object> Request = new Dictionary<string, object>();
-            Request.Add("messageId", ID);
-            Request.Add("command", Enums.Commands.SetRawConfigParameterValue);
-            Request.Add("nodeId", this.id);
-            Request.Add("parameter", Parameter);
-            Request.Add("value", Value);
-
-
-            string RequestPL = Newtonsoft.Json.JsonConvert.SerializeObject(Request);
-            _driver.ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
+            return _driver.SendRequestAsync(request);
         }
 
         // Checked as of : 3.5.0 - Variant 2: Normal parameter, not defined in a config file
         public Task<CMDResult> ZWJSS_SetRawConfigParameterValue(int Parameter, int Value, int ValueSize, Enums.ConfigValueFormat ValueFormat)
         {
-            Guid ID = Guid.NewGuid();
-
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
-            _driver.Callbacks.Add(ID, (JO) =>
+            var request = new Dictionary<string, object>
             {
-                CMDResult Res = new CMDResult(JO);
-                Result.SetResult(Res);
-            });
+                { "command", Enums.Commands.SetRawConfigParameterValue },
+                { "nodeId", this.id },
+                { "parameter", Parameter },
+                { "value", Value },
+                { "valueSize", ValueSize },
+                { "valueFormat", ValueFormat }
+            };
 
-            Dictionary<string, object> Request = new Dictionary<string, object>();
-            Request.Add("messageId", ID);
-            Request.Add("command", Enums.Commands.SetRawConfigParameterValue);
-            Request.Add("nodeId", this.id);
-            Request.Add("parameter", Parameter);
-            Request.Add("value", Value);
-            Request.Add("valueSize", ValueSize);
-            Request.Add("valueFormat", ValueFormat);
-
-
-            string RequestPL = Newtonsoft.Json.JsonConvert.SerializeObject(Request);
-            _driver.ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
+            return _driver.SendRequestAsync(request);
         }
 
         // Checked as of : 3.5.0 - Variant 3: Partial parameter, must be defined in a config file
         public Task<CMDResult> ZWJSS_SetRawConfigParameterValue(int Parameter, int Bitmask, int Value)
         {
-            Guid ID = Guid.NewGuid();
-
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
-            _driver.Callbacks.Add(ID, (JO) =>
+            var request = new Dictionary<string, object>
             {
-                CMDResult Res = new CMDResult(JO);
-                Result.SetResult(Res);
-            });
+                { "command", Enums.Commands.SetRawConfigParameterValue },
+                { "nodeId", this.id },
+                { "parameter", Parameter },
+                { "bitMask", Bitmask },
+                { "value", Value }
+            };
 
-            Dictionary<string, object> Request = new Dictionary<string, object>();
-            Request.Add("messageId", ID);
-            Request.Add("command", Enums.Commands.SetRawConfigParameterValue);
-            Request.Add("nodeId", this.id);
-            Request.Add("parameter", Parameter);
-            Request.Add("bitMask", Bitmask);
-            Request.Add("value", Value);
-
-
-            string RequestPL = Newtonsoft.Json.JsonConvert.SerializeObject(Request);
-            _driver.ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
+            return _driver.SendRequestAsync(request);
         }
         
         // Checked as of : 3.5.0
         public Task<CMDResult> RefreshValues()
         {
-            Guid ID = Guid.NewGuid();
-
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
-            _driver.Callbacks.Add(ID, (JO) =>
+            var request = new Dictionary<string, object>
             {
-                CMDResult Res = new CMDResult(JO);
-                Result.SetResult(Res);
-            });
+                { "command", Enums.Commands.RefreshValues },
+                { "nodeId", this.id }
+            };
 
-            Dictionary<string, object> Request = new Dictionary<string, object>();
-            Request.Add("messageId", ID);
-            Request.Add("command", Enums.Commands.RefreshValues);
-            Request.Add("nodeId", this.id);
-
-
-            string RequestPL = JsonConvert.SerializeObject(Request);
-            _driver.ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
+            return _driver.SendRequestAsync(request);
         }
 
         // Checked as of : 3.5.0
         public Task<CMDResult> RefreshCCValues(int CommandClass)
         {
-            Guid ID = Guid.NewGuid();
-
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
-            _driver.Callbacks.Add(ID, (JO) =>
+            var request = new Dictionary<string, object>
             {
-                CMDResult Res = new CMDResult(JO);
-                Result.SetResult(Res);
-            });
+                { "command", Enums.Commands.RefreshCCValues },
+                { "commandClass", CommandClass },
+                { "nodeId", this.id }
+            };
 
-            Dictionary<string, object> Request = new Dictionary<string, object>();
-            Request.Add("messageId", ID);
-            Request.Add("command", Enums.Commands.RefreshCCValues);
-            Request.Add("commandClass", CommandClass);
-            Request.Add("nodeId", this.id);
-
-
-            string RequestPL = JsonConvert.SerializeObject(Request);
-            _driver.ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
+            return _driver.SendRequestAsync(request);
         }
 
         // Checked as of : 3.5.0
         public Task<CMDResult> GetDefinedValueIDs()
         {
-            Guid ID = Guid.NewGuid();
-
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
-            _driver.Callbacks.Add(ID, (JO) =>
+            var request = new Dictionary<string, object>
             {
-                CMDResult Res = new CMDResult(JO);
+                { "command", Enums.Commands.GetDefinedValueIDs },
+                { "nodeId", this.id }
+            };
+
+            return _driver.SendRequestAsync(request, (JO, Res) =>
+            {
                 if (Res.Success)
                 {
                     Res.SetPayload(JO.SelectToken("result.valueIds").ToObject<ValueID[]>());
                 }
-
-                Result.SetResult(Res);
             });
-
-            Dictionary<string, object> Request = new Dictionary<string, object>();
-            Request.Add("messageId", ID);
-            Request.Add("command", Enums.Commands.GetDefinedValueIDs);
-            Request.Add("nodeId", this.id);
-
-
-            string RequestPL = JsonConvert.SerializeObject(Request);
-            _driver.ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
         }
 
         // Checked as of : 3.5.0
         public Task<CMDResult> GetValueMetadata(ValueID VID)
         {
-            Guid ID = Guid.NewGuid();
-
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
-            _driver.Callbacks.Add(ID, (JO) =>
+            var request = new Dictionary<string, object>
             {
-                CMDResult Res = new CMDResult(JO);
+                { "command", Enums.Commands.GetValueMetadata },
+                { "nodeId", this.id },
+                { "valueId", VID }
+            };
+
+            return _driver.SendRequestAsync(request, (JO, Res) =>
+            {
                 if (Res.Success)
                 {
                     Res.SetPayload(JO.SelectToken("result").ToObject<ValueMetadata>());
                 }
-
-                Result.SetResult(Res);
-
             });
-
-            Dictionary<string, object> Request = new Dictionary<string, object>();
-            Request.Add("messageId", ID);
-            Request.Add("command", Enums.Commands.GetValueMetadata);
-            Request.Add("nodeId", this.id);
-            Request.Add("valueId", VID);
-
-
-            string RequestPL = JsonConvert.SerializeObject(Request);
-            _driver.ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
         }
 
         // Checked as of : 3.5.0
         public Task<CMDResult> SupportsCCAPI(int CommandClass)
         {
-            Guid ID = Guid.NewGuid();
-
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
-            _driver.Callbacks.Add(ID, (JO) =>
+            var request = new Dictionary<string, object>
             {
-                CMDResult Res = new CMDResult(JO);
+                { "command", Enums.Commands.SupportsCCAPI },
+                { "nodeId", this.id },
+                { "commandClass", CommandClass }
+            };
+
+            return _driver.SendRequestAsync(request, (JO, Res) =>
+            {
                 if (Res.Success)
                 {
                     Res.SetPayload(JO.SelectToken("result.supported").ToObject<bool>());
-                    
                 }
-                Result.SetResult(Res);
             });
-
-            Dictionary<string, object> Request = new Dictionary<string, object>();
-            Request.Add("messageId", ID);
-            Request.Add("command", Enums.Commands.SupportsCCAPI);
-            Request.Add("nodeId", this.id);
-            Request.Add("commandClass", CommandClass);
-
-            string RequestPL = JsonConvert.SerializeObject(Request);
-            _driver.ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
         }
 
         // Checked as of : 3.5.0
         public Task<CMDResult> InvokeCCAPI(int CommandClass, string Method, params object[] Params)
         {
-            Guid ID = Guid.NewGuid();
-
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
-            _driver.Callbacks.Add(ID, (JO) =>
+            var request = new Dictionary<string, object>
             {
-                CMDResult Res = new CMDResult(JO);
+                { "command", Enums.Commands.InvokeCCAPI },
+                { "nodeId", this.id },
+                { "commandClass", CommandClass },
+                { "methodName", Method },
+                { "args", Params }
+            };
+
+            return _driver.SendRequestAsync(request, (JO, Res) =>
+            {
                 if (Res.Success)
                 {
                     Res.SetPayload(JO.SelectToken("result").ToObject<JObject>());
                 }
-                Result.SetResult(Res);
-
             });
-
-            Dictionary<string, object> Request = new Dictionary<string, object>();
-            Request.Add("messageId", ID);
-            Request.Add("command", Enums.Commands.InvokeCCAPI);
-            Request.Add("nodeId", this.id);
-            Request.Add("commandClass", CommandClass);
-            Request.Add("methodName", Method);
-            Request.Add("args", Params);
-
-            string RequestPL = JsonConvert.SerializeObject(Request);
-            _driver.ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
         }
 
        
@@ -682,172 +478,101 @@ namespace ZWaveJS.NET
         // Checked as of : 3.5.0
         public Task<CMDResult> GetEndpointCount()
         {
-            Guid ID = Guid.NewGuid();
-
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
-
-            _driver.Callbacks.Add(ID, (JO) =>
+            var request = new Dictionary<string, object>
             {
-                CMDResult Res = new CMDResult(JO);
+                { "command", Enums.Commands.GetEndpointCount },
+                { "nodeId", this.id }
+            };
+
+            return _driver.SendRequestAsync(request, (JO, Res) =>
+            {
                 if (Res.Success)
                 {
                     Res.SetPayload(JO.SelectToken("result.count").ToObject<int>());
                 }
-                Result.SetResult(Res);
             });
-
-            Dictionary<string, object> Request = new Dictionary<string, object>();
-            Request.Add("messageId", ID);
-            Request.Add("command", Enums.Commands.GetEndpointCount);
-            Request.Add("nodeId", this.id);
-
-            string RequestPL = JsonConvert.SerializeObject(Request);
-            _driver.ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
         }
 
         // Checked as of : 3.5.0
         public Task<CMDResult> GetHighestSecurityClass()
         {
-            Guid ID = Guid.NewGuid();
-
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
-
-            _driver.Callbacks.Add(ID, (JO) =>
+            var request = new Dictionary<string, object>
             {
-                CMDResult Res = new CMDResult(JO);
+                { "command", Enums.Commands.GetHighestSecurityClass },
+                { "nodeId", this.id }
+            };
+
+            return _driver.SendRequestAsync(request, (JO, Res) =>
+            {
                 if (Res.Success)
                 {
                     Enums.SecurityClass Value = JO.SelectToken("result.highestSecurityClass").ToObject<Enums.SecurityClass>();
                     Res.SetPayload(Value);
                 }
-                Result.SetResult(Res);
-
-               
             });
-
-            Dictionary<string, object> Request = new Dictionary<string, object>();
-            Request.Add("messageId", ID);
-            Request.Add("command", Enums.Commands.GetHighestSecurityClass);
-            Request.Add("nodeId", this.id);
-
-            string RequestPL = JsonConvert.SerializeObject(Request);
-            _driver.ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
         }
 
         // Checked as of : 3.5.0
         public Task<CMDResult> HasSecurityClass(Enums.SecurityClass Class)
         {
-            Guid ID = Guid.NewGuid();
-
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
-
-            _driver.Callbacks.Add(ID, (JO) =>
+            var request = new Dictionary<string, object>
             {
-                CMDResult Res = new CMDResult(JO);
+                { "command", Enums.Commands.HasSecurityClass },
+                { "nodeId", this.id },
+                { "securityClass", Class }
+            };
+
+            return _driver.SendRequestAsync(request, (JO, Res) =>
+            {
                 if (Res.Success)
                 {
                     Res.SetPayload(JO.SelectToken("result.hasSecurityClass").ToObject<bool>());
                 }
-                Result.SetResult(Res);
-              
             });
-
-            Dictionary<string, object> Request = new Dictionary<string, object>();
-            Request.Add("messageId", ID);
-            Request.Add("command", Enums.Commands.HasSecurityClass);
-            Request.Add("nodeId", this.id);
-            Request.Add("securityClass", Class);
-
-            string RequestPL = JsonConvert.SerializeObject(Request);
-            _driver.ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
         }
 
         // Checked as of : 3.5.0
         public Task<CMDResult> WaitForWakeup()
         {
-            Guid ID = Guid.NewGuid();
-
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
-
-            _driver.Callbacks.Add(ID, (JO) =>
+            var request = new Dictionary<string, object>
             {
-                CMDResult Res = new CMDResult(JO);
-                Result.SetResult(Res);
+                { "command", Enums.Commands.WaitForWakeUp },
+                { "nodeId", this.id }
+            };
 
-            });
-
-            Dictionary<string, object> Request = new Dictionary<string, object>();
-            Request.Add("messageId", ID);
-            Request.Add("command", Enums.Commands.WaitForWakeUp);
-            Request.Add("nodeId", this.id);
-
-            string RequestPL = JsonConvert.SerializeObject(Request);
-            _driver.ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
+            return _driver.SendRequestAsync(request);
         }
 
         // Checked as of : 3.5.0
         public Task<CMDResult> ManuallyIdleNotificationValue(ValueID VID)
         {
-            Guid ID = Guid.NewGuid();
-
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
-
-            _driver.Callbacks.Add(ID, (JO) =>
+            var request = new Dictionary<string, object>
             {
-                CMDResult Res = new CMDResult(JO);
-                Result.SetResult(Res);
+                { "command", Enums.Commands.ManuallyIdleNotificationValue },
+                { "nodeId", this.id },
+                { "valueId", VID }
+            };
 
-            });
-
-            Dictionary<string, object> Request = new Dictionary<string, object>();
-            Request.Add("messageId", ID);
-            Request.Add("command", Enums.Commands.ManuallyIdleNotificationValue);
-            Request.Add("nodeId", this.id);
-            Request.Add("valueId", VID);
-
-            string RequestPL = JsonConvert.SerializeObject(Request);
-            _driver.ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
+            return _driver.SendRequestAsync(request);
         }
 
         // Checked as of : 3.5.0
         public Task<CMDResult> ManuallyIdleNotificationValue(int notificationType, int prevValue, int? endpointIndex = null)
         {
-            Guid ID = Guid.NewGuid();
-
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
-
-            _driver.Callbacks.Add(ID, (JO) =>
+            var request = new Dictionary<string, object>
             {
-                CMDResult Res = new CMDResult(JO);
-                Result.SetResult(Res);
+                { "command", Enums.Commands.ManuallyIdleNotificationValue },
+                { "nodeId", this.id },
+                { "notificationType", notificationType },
+                { "prevValue", prevValue }
+            };
 
-            });
-
-            Dictionary<string, object> Request = new Dictionary<string, object>();
-            Request.Add("messageId", ID);
-            Request.Add("command", Enums.Commands.ManuallyIdleNotificationValue);
-            Request.Add("nodeId", this.id);
-            Request.Add("notificationType", notificationType);
-            Request.Add("prevValue", prevValue);
             if (endpointIndex.HasValue)
             {
-                Request.Add("endpointIndex", endpointIndex.Value);
+                request.Add("endpointIndex", endpointIndex.Value);
             }
 
-            string RequestPL = JsonConvert.SerializeObject(Request);
-            _driver.ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
+            return _driver.SendRequestAsync(request);
         }
 
          // LOCAL
@@ -927,95 +652,62 @@ namespace ZWaveJS.NET
         public bool keepAwake { get; internal set; }
         public Task<CMDResult>  SetKeepAwake(bool Option)
         {
-            Guid ID = Guid.NewGuid();
-
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
-
-            _driver.Callbacks.Add(ID, (JO) =>
+            var request = new Dictionary<string, object>
             {
-                CMDResult Res = new CMDResult(JO);
+                { "command", Enums.Commands.KeepNodeAwake },
+                { "nodeId", this.id },
+                { "keepAwake", Option }
+            };
+
+            return _driver.SendRequestAsync(request, (JO, Res) =>
+            {
                 if (Res.Success)
                 {
                     this.keepAwake = Option;
                 }
-                Result.SetResult(Res);
-
             });
-
-            Dictionary<string, object> Request = new Dictionary<string, object>();
-            Request.Add("messageId", ID);
-            Request.Add("command", Enums.Commands.KeepNodeAwake);
-            Request.Add("nodeId", this.id);
-            Request.Add("keepAwake", Option);
-
-            string RequestPL = JsonConvert.SerializeObject(Request);
-            _driver.ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
         }
 
         [Newtonsoft.Json.JsonProperty]
         public string name { get; internal set; }
         public Task<CMDResult> SetName(string Name, bool UpdateCC = true)
         {
-            Guid ID = Guid.NewGuid();
-
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
-
-            _driver.Callbacks.Add(ID, (JO) =>
+            var request = new Dictionary<string, object>
             {
-                CMDResult Res = new CMDResult(JO);
+                { "command", Enums.Commands.SetName },
+                { "nodeId", this.id },
+                { "name", Name },
+                { "updateCC", UpdateCC }
+            };
+
+            return _driver.SendRequestAsync(request, (JO, Res) =>
+            {
                 if (Res.Success)
                 {
                     this.name = Name;
                 }
-                Result.SetResult(Res);
-
             });
-
-            Dictionary<string, object> Request = new Dictionary<string, object>();
-            Request.Add("messageId", ID);
-            Request.Add("command", Enums.Commands.SetName);
-            Request.Add("nodeId", this.id);
-            Request.Add("name", Name);
-            Request.Add("updateCC", UpdateCC);
-
-            string RequestPL = JsonConvert.SerializeObject(Request);
-            _driver.ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
         }
 
         [Newtonsoft.Json.JsonProperty]
         public string location { get; internal set; }
         public Task<CMDResult> SetLocation(string Location, bool UpdateCC = true)
         {
-            Guid ID = Guid.NewGuid();
-
-            TaskCompletionSource<CMDResult> Result = new TaskCompletionSource<CMDResult>();
-
-            _driver.Callbacks.Add(ID, (JO) =>
+            var request = new Dictionary<string, object>
             {
-                CMDResult Res = new CMDResult(JO);
+                { "command", Enums.Commands.SetLocation },
+                { "nodeId", this.id },
+                { "location", Location },
+                { "updateCC", UpdateCC }
+            };
+
+            return _driver.SendRequestAsync(request, (JO, Res) =>
+            {
                 if (Res.Success)
                 {
                     this.location = Location;
                 }
-                Result.SetResult(Res);
-
             });
-
-            Dictionary<string, object> Request = new Dictionary<string, object>();
-            Request.Add("messageId", ID);
-            Request.Add("command", Enums.Commands.SetLocation);
-            Request.Add("nodeId", this.id);
-            Request.Add("location", Location);
-            Request.Add("updateCC", UpdateCC);
-
-            string RequestPL = JsonConvert.SerializeObject(Request);
-            _driver.ClientWebSocket.SendInstant(RequestPL);
-
-            return Result.Task;
         }
 
     }


### PR DESCRIPTION
Refactor all request methods to centralize `TaskCompletionSource `handling, send-error propagation and callback cleanup. All the methods now call `Driver.SendRequestAsync`

Fix the issue with `remainingDuration `type in `SetValueResult`.

Add `Endpoint.GetCCs` command.